### PR TITLE
feat: add smplx alias

### DIFF
--- a/simplexup/simplexup
+++ b/simplexup/simplexup
@@ -3,7 +3,7 @@ set -eo pipefail
 
 # NOTE: if you make modifications to this script, please increment the version number.
 # WARNING: the SemVer pattern: major.minor.patch must be followed as we use it to determine if the script is up to date.
-SIMPLEXUP_INSTALLER_VERSION="0.0.2"
+SIMPLEXUP_INSTALLER_VERSION="0.0.3"
 
 BASE_DIR=${XDG_CONFIG_HOME:-$HOME}
 SIMPLEX_DIR=${SIMPLEX_DIR:-"$BASE_DIR/.simplex"}
@@ -354,8 +354,10 @@ use() {
       cp "$SIMPLEX_VERSION_DIR/$bin" "$bin_path"
       # Print usage msg
       case $bin in
-        simplex) 
+        simplex)
           say "- $(ensure "$bin_path" -V)"
+          # Create smplx alias pointing to the simplex binary
+          ln -sf "$bin_path" "$SIMPLEX_BIN_DIR/smplx"
         ;;
       esac
 


### PR DESCRIPTION
Adds an alias to create the program `smplx`. 

# Motivation: 
Currently the repo is called `smplx` but the binaries are called `simplex`. The aim is to create a unified name for the binaries.