### PR TITLE
Fix: generate a new block in the end of prepare_signer()

### DIFF
--- a/crates/regtest/src/regtest.rs
+++ b/crates/regtest/src/regtest.rs
@@ -39,6 +39,7 @@ impl Regtest {
         rpc_provider.generate_blocks(100)?;
 
         rpc_provider.send_to_address(&signer.get_address(), btc2sat(bitcoins), None)?;
+        rpc_provider.generate_blocks(1)?;
 
         // wait for electrs to index
         let mut attempts = 0;


### PR DESCRIPTION
The [rpc_provider.send_to_address](https://github.com/RuslanProgrammer/smplx/blob/575abc2beddda0dbb0237b9be70080aaca7efcde/crates/regtest/src/regtest.rs#L41) function does not generate a block, meaning the transaction simply appears in the mempool. 
The current Electrs version uses a time interval and new block events to trigger index iteration. We can generate an extra block to trigger the index.

This fix should resolve the problem of long regtest startup times (from 6s to 2s).