### PR TITLE
Add the auth and ports config support for the project manifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [Unreleased]
+
+- Add the auth and ports config support for the project manifest.
+
 ## [0.0.3]
 
 - Flattened `simplex test` command interface. Removed `run` and `integration` nesting.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -430,6 +430,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -664,6 +665,15 @@ name = "hex_lit"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3011d1213f159867b13cfd6ac92d2cd5f1345762c63be3554e84092d85a50bbd"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "home"
@@ -1340,7 +1350,10 @@ name = "smplx-regtest"
 version = "0.0.3"
 dependencies = [
  "electrsd",
+ "hex",
+ "hmac",
  "serde",
+ "sha2",
  "smplx-sdk",
  "thiserror",
  "toml 0.9.12+spec-1.1.0",
@@ -1411,6 +1424,12 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ smplx-std = { path = "./crates/simplex", version = "0.0.3" }
 
 serde = { version = "1.0.228", features = ["derive"]}
 hex = { version = "0.4.3" }
+hmac = { version = "0.12.1" }
 sha2 = { version = "0.10.9", features = ["compress"] }
 thiserror = { version = "2.0.18" }
 toml = { version = "0.9.8" }

--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ out_dir = "./src/artifacts"
 [regtest]
 mnemonic = "exist carry drive collect lend cereal occur much tiger just involve mean"
 bitcoins = 10_000_000
+rpc_port = 18443
+esplora_port = 3000
+rpc_user = "user"
+rpc_password = "password"
 
 [test]
 mnemonic = "exist carry drive collect lend cereal occur much tiger just involve mean"
@@ -82,6 +86,10 @@ Where:
 - `regtest` (`simplex regtest` config)
   - `mnemonic` - The signer's mnemonic regtest will send initial funds to.
   - `bitcoins` - Initial coins available to the signer
+  - `rpc_port` - The port Elements regtest node will listen on.
+  - `esplora_port` - The port Electrs will listen on.
+  - `rpc_user` - Elements regtest RPC username.
+  - `rpc_password` - Elements regtest RPC password.
 - `test` (`simplex test` config)
   - `esplora`
     - `url` - Esplora API endpoint url

--- a/crates/cli/assets/Simplex.default.toml
+++ b/crates/cli/assets/Simplex.default.toml
@@ -8,6 +8,10 @@
 # [regtest]
 # mnemonic = "exist carry drive collect lend cereal occur much tiger just involve mean"
 # bitcoins = 10_000_000
+# rpc_port = 18443
+# esplora_port = 3000
+# rpc_user = "user"
+# rpc_password = "password"
 
 # [test]
 # mnemonic = "exist carry drive collect lend cereal occur much tiger just involve mean"

--- a/crates/regtest/Cargo.toml
+++ b/crates/regtest/Cargo.toml
@@ -17,3 +17,6 @@ thiserror = { workspace = true }
 electrsd = { workspace = true }
 serde = { workspace = true }
 toml = { workspace = true }
+hmac = { workspace = true }
+sha2 = { workspace = true }
+hex = { workspace = true }

--- a/crates/regtest/src/args.rs
+++ b/crates/regtest/src/args.rs
@@ -1,5 +1,12 @@
-pub fn get_elementsd_bin_args() -> Vec<String> {
-    vec![
+use hmac::{Hmac, Mac};
+use sha2::Sha256;
+
+use super::RegtestConfig;
+
+type HmacSha256 = Hmac<Sha256>;
+
+pub fn get_elementsd_bin_args(config: &RegtestConfig) -> Vec<String> {
+    let mut args = vec![
         "-fallbackfee=0.0001".to_string(),
         "-dustrelayfee=0.00000001".to_string(),
         "-acceptdiscountct=1".to_string(),
@@ -14,9 +21,40 @@ pub fn get_elementsd_bin_args() -> Vec<String> {
         "-listen=1".to_string(),
         "-txindex=1".to_string(),
         "-multi_data_permitted".to_string(),
-    ]
+    ];
+
+    if let Some(port) = config.rpc_port {
+        // A lib works with autoassigned rpcport, so we are required to do this woodoo
+        args.push("-rpcbind=127.0.0.1".to_string());
+        args.push(format!("-rpcbind=127.0.0.1:{port}"));
+        args.push("-rpcallowip=127.0.0.1/8".to_string());
+    }
+
+    if let (Some(user), Some(password)) = (&config.rpc_user, &config.rpc_password) {
+        let rpcauth = generate_rpcauth(user, password);
+        args.push(format!("-rpcauth={rpcauth}"));
+    }
+
+    args
 }
 
-pub fn get_electrs_bin_args() -> Vec<String> {
-    vec![]
+pub fn get_electrs_bin_args(config: &RegtestConfig) -> Vec<String> {
+    let mut args = vec![];
+
+    if let Some(port) = config.esplora_port {
+        args.push(format!("--http-addr=0.0.0.0:{port}"));
+    }
+
+    args
+}
+
+/// Generates an rpcauth string in the format `user:salt$hash`
+fn generate_rpcauth(user: &str, password: &str) -> String {
+    let salt = hex::encode(user.as_bytes());
+
+    let mut mac = HmacSha256::new_from_slice(salt.as_bytes()).expect("HMAC accepts key of any size");
+    mac.update(password.as_bytes());
+    let hash = hex::encode(mac.finalize().into_bytes());
+
+    format!("{user}:{salt}${hash}")
 }

--- a/crates/regtest/src/client.rs
+++ b/crates/regtest/src/client.rs
@@ -6,24 +6,28 @@ use electrsd::bitcoind;
 use electrsd::bitcoind::bitcoincore_rpc::Auth;
 use electrsd::bitcoind::{BitcoinD, Conf};
 
+use super::RegtestConfig;
 use super::error::RegtestError;
 use crate::args::{get_electrs_bin_args, get_elementsd_bin_args};
 
 pub struct RegtestClient {
     pub electrs: ElectrsD,
     pub elements: BitcoinD,
+    config: RegtestConfig,
 }
 
 impl RegtestClient {
-    // TODO: pass custom config, remove clippy tag
-    #[allow(clippy::new_without_default)]
-    pub fn new() -> Self {
+    pub fn new(config: &RegtestConfig) -> Self {
         let (electrs_path, elementsd_path) = Self::default_bin_paths();
         let zmq_addr = Self::get_zmq_addr();
-        let elements = Self::create_bitcoind_node(elementsd_path, &zmq_addr);
-        let electrs = Self::create_electrs_node(electrs_path, &elements, &zmq_addr);
+        let elements = Self::create_bitcoind_node(elementsd_path, &zmq_addr, config);
+        let electrs = Self::create_electrs_node(electrs_path, &elements, &zmq_addr, config);
 
-        Self { electrs, elements }
+        Self {
+            electrs,
+            elements,
+            config: config.clone(),
+        }
     }
 
     pub fn default_bin_paths() -> (PathBuf, PathBuf) {
@@ -37,19 +41,29 @@ impl RegtestClient {
     }
 
     pub fn rpc_url(&self) -> String {
+        if let Some(port) = self.config.rpc_port {
+            return format!("http://127.0.0.1:{port}");
+        }
+
         self.elements.rpc_url()
     }
 
     pub fn esplora_url(&self) -> String {
+        if let Some(port) = self.config.esplora_port {
+            return format!("http://127.0.0.1:{port}");
+        }
+
         let url = self.electrs.esplora_url.clone().unwrap();
         let port = url.split_once(":").unwrap().1;
-
         format!("http://127.0.0.1:{}", port)
     }
 
     pub fn auth(&self) -> Auth {
-        let cookie = self.elements.params.get_cookie_values().unwrap().unwrap();
+        if let (Some(user), Some(password)) = (&self.config.rpc_user, &self.config.rpc_password) {
+            return Auth::UserPass(user.clone(), password.clone());
+        }
 
+        let cookie = self.elements.params.get_cookie_values().unwrap().unwrap();
         Auth::UserPass(cookie.user, cookie.password)
     }
 
@@ -68,9 +82,9 @@ impl RegtestClient {
             .to_string()
     }
 
-    fn create_bitcoind_node(bin_path: impl AsRef<Path>, zmq_addr: &String) -> BitcoinD {
+    fn create_bitcoind_node(bin_path: impl AsRef<Path>, zmq_addr: &String, config: &RegtestConfig) -> BitcoinD {
         let mut conf = Conf::default();
-        let mut bin_args = get_elementsd_bin_args();
+        let mut bin_args = get_elementsd_bin_args(config);
 
         bin_args.push(format!("-zmqpubrawtx=tcp://{zmq_addr}"));
         bin_args.push(format!("-zmqpubrawblock=tcp://{zmq_addr}"));
@@ -85,14 +99,19 @@ impl RegtestClient {
         BitcoinD::with_conf(bin_path.as_ref(), &conf).unwrap()
     }
 
-    fn create_electrs_node(bin_path: impl AsRef<Path>, elementsd: &BitcoinD, zmq_addr: &String) -> ElectrsD {
+    fn create_electrs_node(
+        bin_path: impl AsRef<Path>,
+        elementsd: &BitcoinD,
+        zmq_addr: &String,
+        config: &RegtestConfig,
+    ) -> ElectrsD {
         let mut conf = electrsd::Conf::default();
-        let mut bin_args = get_electrs_bin_args();
+        let mut bin_args = get_electrs_bin_args(config);
 
         bin_args.push(format!("--zmq-addr={zmq_addr}"));
 
         conf.args = bin_args.iter().map(|x| x.as_ref()).collect::<Vec<&str>>();
-        conf.http_enabled = true;
+        conf.http_enabled = config.esplora_port.is_none();
         conf.network = "liquidregtest";
 
         ElectrsD::with_conf(bin_path.as_ref(), elementsd, &conf).unwrap()

--- a/crates/regtest/src/config.rs
+++ b/crates/regtest/src/config.rs
@@ -14,6 +14,10 @@ pub const DEFAULT_BITCOINS: u64 = 10_000_000;
 pub struct RegtestConfig {
     pub mnemonic: String,
     pub bitcoins: u64,
+    pub rpc_port: Option<u16>,
+    pub esplora_port: Option<u16>,
+    pub rpc_user: Option<String>,
+    pub rpc_password: Option<String>,
 }
 
 impl RegtestConfig {
@@ -32,6 +36,10 @@ impl Default for RegtestConfig {
         Self {
             mnemonic: DEFAULT_REGTEST_MNEMONIC.to_string(),
             bitcoins: DEFAULT_BITCOINS,
+            rpc_port: None,
+            esplora_port: None,
+            rpc_user: None,
+            rpc_password: None,
         }
     }
 }

--- a/crates/regtest/src/regtest.rs
+++ b/crates/regtest/src/regtest.rs
@@ -14,7 +14,7 @@ pub struct Regtest {}
 
 impl Regtest {
     pub fn from_config(config: RegtestConfig) -> Result<(RegtestClient, Signer), RegtestError> {
-        let client = RegtestClient::new();
+        let client = RegtestClient::new(&config);
 
         let provider = Box::new(SimplexProvider::new(
             client.esplora_url(),

--- a/crates/test/src/config.rs
+++ b/crates/test/src/config.rs
@@ -50,6 +50,10 @@ impl TestConfig {
         RegtestConfig {
             mnemonic: self.mnemonic.clone(),
             bitcoins: self.bitcoins,
+            rpc_port: None,
+            esplora_port: None,
+            rpc_user: None,
+            rpc_password: None,
         }
     }
 

--- a/deny.toml
+++ b/deny.toml
@@ -101,6 +101,7 @@ allow = [
     "WTFPL",
     "Zlib",
     "MITNFA",
+    "BSD-3-Clause",
 ]
 # The confidence threshold for detecting a license from license text.
 # The higher the value, the more closely the license text must be to the


### PR DESCRIPTION
This PR introduces an optional configuration interface that allows users to specify elements daemon RPC settings and Esplora port mappings.

The changes are fully backward-compatible with existing Simplex.toml files.

Example of the new regtest config:
```toml
[regtest]
mnemonic = "exist carry drive collect lend cereal occur much tiger just involve mean"
bitcoins = 10_000_000
rpc_port = 18443
esplora_port = 3000
rpc_user = "user"
rpc_password = "password"
```