### PR TITLE
fix: `simplex test` runs non-simplex test when no args provided

### DIFF
--- a/crates/cli/src/cli.rs
+++ b/crates/cli/src/cli.rs
@@ -7,7 +7,7 @@ use crate::commands::build::Build;
 use crate::commands::clean::Clean;
 use crate::commands::init::Init;
 use crate::commands::regtest::Regtest;
-use crate::commands::test::Test;
+use crate::commands::test::{Test, TestRequest, TestTargets};
 use crate::config::Config;
 use crate::error::CliError;
 
@@ -38,13 +38,23 @@ impl Cli {
                 Ok(())
             }
             Command::Test {
-                tests,
+                filter,
+                integration_tests,
                 additional_flags,
             } => {
                 let config_path = Config::get_default_path()?;
                 let loaded_config = Config::load(config_path)?;
 
-                Ok(Test::run(loaded_config.test, tests, additional_flags)?)
+                let test_request = if filter.is_none() && integration_tests.is_empty() {
+                    TestRequest::All
+                } else {
+                    TestRequest::TestTargets(TestTargets {
+                        filter: filter.as_deref(),
+                        integration_tests,
+                    })
+                };
+
+                Ok(Test::run(loaded_config.test, &test_request, additional_flags)?)
             }
             Command::Regtest => {
                 let config_path = Config::get_default_path()?;

--- a/crates/cli/src/cli.rs
+++ b/crates/cli/src/cli.rs
@@ -7,7 +7,7 @@ use crate::commands::build::Build;
 use crate::commands::clean::Clean;
 use crate::commands::init::Init;
 use crate::commands::regtest::Regtest;
-use crate::commands::test::{Test, TestRequest, TestTargets};
+use crate::commands::test::Test;
 use crate::config::Config;
 use crate::error::CliError;
 
@@ -37,24 +37,13 @@ impl Cli {
 
                 Ok(())
             }
-            Command::Test {
-                filter,
-                integration_tests,
-                additional_flags,
-            } => {
+            Command::Test { name, additional_flags } => {
                 let config_path = Config::get_default_path()?;
                 let loaded_config = Config::load(config_path)?;
 
-                let test_request = if filter.is_none() && integration_tests.is_empty() {
-                    TestRequest::All
-                } else {
-                    TestRequest::TestTargets(TestTargets {
-                        filter: filter.as_deref(),
-                        integration_tests,
-                    })
-                };
+                let filter = name.clone().unwrap_or_default();
 
-                Ok(Test::run(loaded_config.test, &test_request, additional_flags)?)
+                Ok(Test::run(loaded_config.test, filter, additional_flags)?)
             }
             Command::Regtest => {
                 let config_path = Config::get_default_path()?;

--- a/crates/cli/src/commands/core.rs
+++ b/crates/cli/src/commands/core.rs
@@ -9,17 +9,13 @@ pub enum Command {
     },
     /// Prints current Simplex config in use
     Config,
-    /// Spins up the local Electrs + Elements regtest
+    /// Spins up local Electrs + Elements regtest
     Regtest,
     /// Runs Simplex tests
     Test {
-        /// Name of test to run
+        /// Name or a substring of the tests to run
         #[arg()]
-        filter: Option<String>,
-
-        /// Integration tests to run
-        #[arg(long = "test", num_args = 1)]
-        integration_tests: Vec<String>,
+        name: Option<String>,
 
         #[command(flatten)]
         additional_flags: TestFlags,

--- a/crates/cli/src/commands/core.rs
+++ b/crates/cli/src/commands/core.rs
@@ -13,9 +13,14 @@ pub enum Command {
     Regtest,
     /// Runs Simplex tests
     Test {
-        /// The list of test names to run
-        #[arg(long)]
-        tests: Vec<String>,
+        /// Name of test to run
+        #[arg()]
+        filter: Option<String>,
+
+        /// Integration tests to run
+        #[arg(long = "test", num_args = 1)]
+        integration_tests: Vec<String>,
+
         #[command(flatten)]
         additional_flags: TestFlags,
     },

--- a/crates/cli/src/commands/test.rs
+++ b/crates/cli/src/commands/test.rs
@@ -5,15 +5,24 @@ use smplx_test::{SMPLX_TEST_MARKER, TestConfig};
 
 use super::core::TestFlags;
 use super::error::CommandError;
+pub struct TestTargets<'a> {
+    pub filter: Option<&'a str>,
+    pub integration_tests: &'a [String],
+}
+
+pub enum TestRequest<'a> {
+    All,
+    TestTargets(TestTargets<'a>),
+}
 
 pub struct Test {}
 
 impl Test {
-    pub fn run(config: TestConfig, tests: &[String], flags: &TestFlags) -> Result<(), CommandError> {
+    pub fn run(config: TestConfig, test_request: &TestRequest, flags: &TestFlags) -> Result<(), CommandError> {
         let cache_path = Self::get_test_config_cache_name()?;
         config.to_file(&cache_path)?;
 
-        let mut cargo_test_command = Self::build_cargo_test_command(&cache_path, tests, flags);
+        let mut cargo_test_command = Self::build_cargo_test_command(&cache_path, test_request, flags);
 
         let output = cargo_test_command.output()?;
 
@@ -33,10 +42,14 @@ impl Test {
         Ok(())
     }
 
-    fn build_cargo_test_command(cache_path: &PathBuf, tests: &[String], flags: &TestFlags) -> std::process::Command {
+    fn build_cargo_test_command(
+        cache_path: &PathBuf,
+        test_request: &TestRequest,
+        flags: &TestFlags,
+    ) -> std::process::Command {
         let mut cargo_test_command = std::process::Command::new("sh");
 
-        cargo_test_command.args(["-c".to_string(), Self::build_test_command(tests, flags)]);
+        cargo_test_command.args(["-c".to_string(), Self::build_test_command(test_request, flags)]);
 
         cargo_test_command
             .env(smplx_test::TEST_ENV_NAME, cache_path)
@@ -47,23 +60,34 @@ impl Test {
         cargo_test_command
     }
 
-    fn build_test_command(tests: &[String], flags: &TestFlags) -> String {
+    fn build_test_command(test_request: &TestRequest, flags: &TestFlags) -> String {
         let mut command_as_arg = String::new();
 
-        if tests.is_empty() {
-            command_as_arg.push_str(&format!("cargo test --tests -- _{}", SMPLX_TEST_MARKER));
-        } else {
-            let mut arg = "cargo test".to_string();
-
-            for test_name in tests {
-                arg.push_str(&format!(" --test {test_name}"));
+        match test_request {
+            TestRequest::All => {
+                command_as_arg.push_str(&format!("cargo test --tests -- _{SMPLX_TEST_MARKER}"));
             }
+            TestRequest::TestTargets(TestTargets {
+                filter: filter_by_name,
+                integration_tests,
+            }) => {
+                let mut arg = "cargo test".to_string();
 
-            command_as_arg.push_str(&arg);
+                if let Some(filter) = filter_by_name {
+                    arg.push_str(&format!(" {filter}_{SMPLX_TEST_MARKER}"));
+                } else {
+                    arg.push_str(&format!(" _{SMPLX_TEST_MARKER}"));
+                }
+
+                for integration_test in *integration_tests {
+                    arg.push_str(&format!(" --test {integration_test}"));
+                }
+
+                command_as_arg.push_str(&arg);
+            }
         }
 
         let flag_args = Self::build_test_flags(flags);
-
         if !flag_args.is_empty() {
             command_as_arg.push_str(" --");
             command_as_arg.push_str(&flag_args);

--- a/crates/cli/src/commands/test.rs
+++ b/crates/cli/src/commands/test.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 use std::process::Stdio;
 
-use smplx_test::TestConfig;
+use smplx_test::{SMPLX_TEST_MARKER, TestConfig};
 
 use super::core::TestFlags;
 use super::error::CommandError;
@@ -51,7 +51,7 @@ impl Test {
         let mut command_as_arg = String::new();
 
         if tests.is_empty() {
-            command_as_arg.push_str("cargo test --tests");
+            command_as_arg.push_str(&format!("cargo test --tests -- _{}", SMPLX_TEST_MARKER));
         } else {
             let mut arg = "cargo test".to_string();
 

--- a/crates/cli/src/commands/test.rs
+++ b/crates/cli/src/commands/test.rs
@@ -5,24 +5,15 @@ use smplx_test::{SMPLX_TEST_MARKER, TestConfig};
 
 use super::core::TestFlags;
 use super::error::CommandError;
-pub struct TestTargets<'a> {
-    pub filter: Option<&'a str>,
-    pub integration_tests: &'a [String],
-}
-
-pub enum TestRequest<'a> {
-    All,
-    TestTargets(TestTargets<'a>),
-}
 
 pub struct Test {}
 
 impl Test {
-    pub fn run(config: TestConfig, test_request: &TestRequest, flags: &TestFlags) -> Result<(), CommandError> {
+    pub fn run(config: TestConfig, filter: String, flags: &TestFlags) -> Result<(), CommandError> {
         let cache_path = Self::get_test_config_cache_name()?;
         config.to_file(&cache_path)?;
 
-        let mut cargo_test_command = Self::build_cargo_test_command(&cache_path, test_request, flags);
+        let mut cargo_test_command = Self::build_cargo_test_command(&cache_path, filter, flags);
 
         let output = cargo_test_command.output()?;
 
@@ -42,14 +33,10 @@ impl Test {
         Ok(())
     }
 
-    fn build_cargo_test_command(
-        cache_path: &PathBuf,
-        test_request: &TestRequest,
-        flags: &TestFlags,
-    ) -> std::process::Command {
+    fn build_cargo_test_command(cache_path: &PathBuf, filter: String, flags: &TestFlags) -> std::process::Command {
         let mut cargo_test_command = std::process::Command::new("sh");
 
-        cargo_test_command.args(["-c".to_string(), Self::build_test_command(test_request, flags)]);
+        cargo_test_command.args(["-c".to_string(), Self::build_test_command(filter, flags)]);
 
         cargo_test_command
             .env(smplx_test::TEST_ENV_NAME, cache_path)
@@ -60,34 +47,13 @@ impl Test {
         cargo_test_command
     }
 
-    fn build_test_command(test_request: &TestRequest, flags: &TestFlags) -> String {
+    fn build_test_command(filter: String, flags: &TestFlags) -> String {
         let mut command_as_arg = String::new();
 
-        match test_request {
-            TestRequest::All => {
-                command_as_arg.push_str(&format!("cargo test --tests -- _{SMPLX_TEST_MARKER}"));
-            }
-            TestRequest::TestTargets(TestTargets {
-                filter: filter_by_name,
-                integration_tests,
-            }) => {
-                let mut arg = "cargo test".to_string();
-
-                if let Some(filter) = filter_by_name {
-                    arg.push_str(&format!(" {filter}_{SMPLX_TEST_MARKER}"));
-                } else {
-                    arg.push_str(&format!(" _{SMPLX_TEST_MARKER}"));
-                }
-
-                for integration_test in *integration_tests {
-                    arg.push_str(&format!(" --test {integration_test}"));
-                }
-
-                command_as_arg.push_str(&arg);
-            }
-        }
+        command_as_arg.push_str(&format!("cargo test {filter}_{SMPLX_TEST_MARKER}"));
 
         let flag_args = Self::build_test_flags(flags);
+
         if !flag_args.is_empty() {
             command_as_arg.push_str(" --");
             command_as_arg.push_str(&flag_args);

--- a/crates/test/src/lib.rs
+++ b/crates/test/src/lib.rs
@@ -4,3 +4,4 @@ pub mod error;
 pub mod macros;
 
 pub use config::{RpcConfig, TEST_ENV_NAME, TestConfig};
+pub use macros::core::SMPLX_TEST_MARKER;

--- a/crates/test/src/macros/core.rs
+++ b/crates/test/src/macros/core.rs
@@ -3,6 +3,8 @@ use syn::parse::Parser;
 
 use crate::TEST_ENV_NAME;
 
+pub const SMPLX_TEST_MARKER: &str = "_smplx_test";
+
 type AttributeArgs = syn::punctuated::Punctuated<syn::Meta, syn::Token![,]>;
 
 pub fn expand(args: TokenStream, input: syn::ItemFn) -> syn::Result<TokenStream> {
@@ -15,7 +17,7 @@ pub fn expand(args: TokenStream, input: syn::ItemFn) -> syn::Result<TokenStream>
 // TODO: args?
 fn expand_inner(input: &syn::ItemFn, _args: AttributeArgs) -> syn::Result<proc_macro2::TokenStream> {
     let ret = &input.sig.output;
-    let name = &input.sig.ident;
+    let name = quote::format_ident!("{}_{}", &input.sig.ident.to_string(), SMPLX_TEST_MARKER);
     let inputs = &input.sig.inputs;
     let body = &input.block;
     let attrs = &input.attrs;

--- a/examples/basic/tests/ignore_default_tests.rs
+++ b/examples/basic/tests/ignore_default_tests.rs
@@ -1,0 +1,15 @@
+// Dummy test to insure that `simplex test` runs only `#[simplex::test]` functions
+
+#[cfg(test)]
+mod test {
+
+    #[simplex::test]
+    fn smplx_test_invoked(_: simplex::TestContext) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    #[test]
+    fn default_tests_should_not_be_invoked() {
+        panic!()
+    }
+}


### PR DESCRIPTION
Fixes #53 