### PR TITLE
smplx_sdk: add wrapper over Txid for wait behaviour (TxReceipt)

### DIFF
--- a/crates/sdk/src/provider/core.rs
+++ b/crates/sdk/src/provider/core.rs
@@ -5,7 +5,7 @@ use electrsd::bitcoind::bitcoincore_rpc::Auth;
 use simplicityhl::elements::{Address, Script, Transaction, Txid};
 
 use crate::provider::SimplicityNetwork;
-use crate::transaction::UTXO;
+use crate::transaction::{TxReceipt, UTXO};
 
 use super::error::ProviderError;
 
@@ -22,7 +22,7 @@ pub struct ProviderInfo {
 pub trait ProviderTrait {
     fn get_network(&self) -> &SimplicityNetwork;
 
-    fn broadcast_transaction(&self, tx: &Transaction) -> Result<Txid, ProviderError>;
+    fn broadcast_transaction(&self, tx: &Transaction) -> Result<TxReceipt<'_>, ProviderError>;
 
     fn wait(&self, txid: &Txid) -> Result<(), ProviderError>;
 

--- a/crates/sdk/src/provider/esplora.rs
+++ b/crates/sdk/src/provider/esplora.rs
@@ -11,7 +11,7 @@ use simplicityhl::elements::{Address, OutPoint, Script, Transaction, Txid};
 use serde::Deserialize;
 
 use crate::provider::SimplicityNetwork;
-use crate::transaction::UTXO;
+use crate::transaction::{TxReceipt, UTXO};
 
 use super::core::{DEFAULT_ESPLORA_TIMEOUT_SECS, ProviderTrait};
 use super::error::ProviderError;
@@ -101,7 +101,7 @@ impl ProviderTrait for EsploraProvider {
         &self.network
     }
 
-    fn broadcast_transaction(&self, tx: &Transaction) -> Result<Txid, ProviderError> {
+    fn broadcast_transaction(&self, tx: &Transaction) -> Result<TxReceipt<'_>, ProviderError> {
         let tx_hex = encode::serialize_hex(tx);
         let url = format!("{}/tx", self.esplora_url);
         let timeout_secs = self.timeout.as_secs();
@@ -123,7 +123,9 @@ impl ProviderTrait for EsploraProvider {
             });
         }
 
-        Txid::from_str(&body).map_err(|e| ProviderError::InvalidTxid(e.to_string()))
+        Txid::from_str(&body)
+            .map_err(|e| ProviderError::InvalidTxid(e.to_string()))
+            .map(|tx_id| TxReceipt::new(self, tx_id))
     }
 
     fn wait(&self, txid: &Txid) -> Result<(), ProviderError> {

--- a/crates/sdk/src/provider/simplex.rs
+++ b/crates/sdk/src/provider/simplex.rs
@@ -5,7 +5,7 @@ use electrsd::bitcoind::bitcoincore_rpc::Auth;
 use simplicityhl::elements::{Address, Script, Transaction, Txid};
 
 use crate::provider::SimplicityNetwork;
-use crate::transaction::UTXO;
+use crate::transaction::{TxReceipt, UTXO};
 
 use super::core::ProviderTrait;
 use super::error::ProviderError;
@@ -30,12 +30,12 @@ impl ProviderTrait for SimplexProvider {
         self.esplora.get_network()
     }
 
-    fn broadcast_transaction(&self, tx: &Transaction) -> Result<Txid, ProviderError> {
-        let txid = self.esplora.broadcast_transaction(tx)?;
+    fn broadcast_transaction(&self, tx: &Transaction) -> Result<TxReceipt<'_>, ProviderError> {
+        let tx_receipt = self.esplora.broadcast_transaction(tx)?;
 
         self.elements.generate_blocks(1)?;
 
-        Ok(txid)
+        Ok(tx_receipt)
     }
 
     fn wait(&self, txid: &Txid) -> Result<(), ProviderError> {

--- a/crates/sdk/src/signer/core.rs
+++ b/crates/sdk/src/signer/core.rs
@@ -33,7 +33,7 @@ use crate::program::ProgramTrait;
 use crate::provider::ProviderTrait;
 use crate::provider::SimplicityNetwork;
 use crate::signer::wtns_injector::WtnsInjector;
-use crate::transaction::{FinalTransaction, PartialInput, PartialOutput, RequiredSignature, UTXO};
+use crate::transaction::{FinalTransaction, PartialInput, PartialOutput, RequiredSignature, TxReceipt, UTXO};
 
 use super::error::SignerError;
 
@@ -130,7 +130,7 @@ impl Signer {
     }
 
     // TODO: add an ability to send arbitrary assets
-    pub fn send(&self, to: Script, amount: u64) -> Result<Txid, SignerError> {
+    pub fn send(&self, to: Script, amount: u64) -> Result<TxReceipt<'_>, SignerError> {
         let mut ft = FinalTransaction::new();
 
         ft.add_output(PartialOutput::new(to, amount, self.network.policy_asset()));
@@ -140,7 +140,7 @@ impl Signer {
         Ok(self.provider.broadcast_transaction(&tx)?)
     }
 
-    pub fn broadcast(&self, tx: &FinalTransaction) -> Result<Txid, SignerError> {
+    pub fn broadcast(&self, tx: &FinalTransaction) -> Result<TxReceipt<'_>, SignerError> {
         let (tx, _fee) = self.finalize(tx)?;
 
         Ok(self.provider.broadcast_transaction(&tx)?)

--- a/crates/sdk/src/transaction/mod.rs
+++ b/crates/sdk/src/transaction/mod.rs
@@ -1,9 +1,11 @@
 pub mod final_transaction;
 pub mod partial_input;
 pub mod partial_output;
+pub mod tx_receipt;
 pub mod utxo;
 
 pub use final_transaction::{FinalInput, FinalTransaction, IssuanceDetails};
 pub use partial_input::{PartialInput, ProgramInput, RequiredSignature};
 pub use partial_output::PartialOutput;
+pub use tx_receipt::TxReceipt;
 pub use utxo::UTXO;

--- a/crates/sdk/src/transaction/tx_receipt.rs
+++ b/crates/sdk/src/transaction/tx_receipt.rs
@@ -34,7 +34,7 @@ impl<'a> TxReceipt<'a> {
         Self { provider, tx_id }
     }
 
-    pub fn into_txid(self) -> Txid {
+    pub fn txid(self) -> Txid {
         self.tx_id
     }
 

--- a/crates/sdk/src/transaction/tx_receipt.rs
+++ b/crates/sdk/src/transaction/tx_receipt.rs
@@ -1,0 +1,45 @@
+use std::fmt;
+use std::fmt::{Debug, Display, Formatter};
+
+use simplicityhl::elements::Txid;
+
+use crate::provider::{ProviderError, ProviderTrait};
+
+#[derive(Clone, Copy)]
+pub struct TxReceipt<'a> {
+    provider: &'a dyn ProviderTrait,
+    tx_id: Txid,
+}
+
+impl Display for TxReceipt<'_> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        Display::fmt(&self.tx_id, f)
+    }
+}
+
+impl Debug for TxReceipt<'_> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        Debug::fmt(&self.tx_id, f)
+    }
+}
+
+impl AsRef<Txid> for TxReceipt<'_> {
+    fn as_ref(&self) -> &Txid {
+        &self.tx_id
+    }
+}
+
+impl<'a> TxReceipt<'a> {
+    pub fn new(provider: &'a dyn ProviderTrait, tx_id: Txid) -> Self {
+        Self { provider, tx_id }
+    }
+
+    pub fn into_txid(self) -> Txid {
+        self.tx_id
+    }
+
+    #[inline]
+    pub fn wait(&self) -> Result<(), ProviderError> {
+        self.provider.wait(&self.tx_id)
+    }
+}

--- a/examples/basic/tests/basic_test.rs
+++ b/examples/basic/tests/basic_test.rs
@@ -1,7 +1,7 @@
-use simplex::simplicityhl::elements::{Script, Txid};
+use simplex::simplicityhl::elements::Script;
 
 use simplex::constants::DUMMY_SIGNATURE;
-use simplex::transaction::{FinalTransaction, PartialInput, ProgramInput, RequiredSignature};
+use simplex::transaction::{FinalTransaction, PartialInput, ProgramInput, RequiredSignature, TxReceipt};
 
 use simplex_example::artifacts::p2pk::P2pkProgram;
 use simplex_example::artifacts::p2pk::derived_p2pk::{P2pkArguments, P2pkWitness};
@@ -19,18 +19,18 @@ fn get_p2pk(context: &simplex::TestContext) -> (P2pkProgram, Script) {
     (p2pk, p2pk_script)
 }
 
-fn spend_p2wpkh(context: &simplex::TestContext) -> anyhow::Result<Txid> {
+fn spend_p2wpkh(context: &simplex::TestContext) -> anyhow::Result<TxReceipt<'_>> {
     let signer = context.get_default_signer();
 
     let (_, p2pk_script) = get_p2pk(context);
 
-    let txid = signer.send(p2pk_script.clone(), 50)?;
-    println!("Broadcast: {}", txid);
+    let tx_receipt = signer.send(p2pk_script.clone(), 50)?;
+    println!("Broadcast: {}", tx_receipt);
 
-    Ok(txid)
+    Ok(tx_receipt)
 }
 
-fn spend_p2pk(context: &simplex::TestContext) -> anyhow::Result<Txid> {
+fn spend_p2pk(context: &simplex::TestContext) -> anyhow::Result<TxReceipt<'_>> {
     let signer = context.get_default_signer();
     let provider = context.get_default_provider();
 
@@ -52,24 +52,22 @@ fn spend_p2pk(context: &simplex::TestContext) -> anyhow::Result<Txid> {
         RequiredSignature::Witness("SIGNATURE".to_string()),
     );
 
-    let txid = signer.broadcast(&ft)?;
-    println!("Broadcast: {}", txid);
+    let tx_receipt = signer.broadcast(&ft)?;
+    println!("Broadcast: {}", tx_receipt);
 
-    Ok(txid)
+    Ok(tx_receipt)
 }
 
 #[simplex::test]
 fn basic_test(context: simplex::TestContext) -> anyhow::Result<()> {
-    let provider = context.get_default_provider();
+    let tx_receipt = spend_p2wpkh(&context)?;
 
-    let txid = spend_p2wpkh(&context)?;
-
-    provider.wait(&txid)?;
+    tx_receipt.wait()?;
     println!("Confirmed");
 
-    let txid = spend_p2pk(&context)?;
+    let tx_receipt = spend_p2pk(&context)?;
 
-    provider.wait(&txid)?;
+    tx_receipt.wait()?;
     println!("Confirmed");
 
     Ok(())

--- a/examples/basic/tests/confidential_test.rs
+++ b/examples/basic/tests/confidential_test.rs
@@ -1,10 +1,10 @@
-use simplex::simplicityhl::elements::{AssetId, Txid};
+use simplex::simplicityhl::elements::AssetId;
 
 use simplex::signer::Signer;
 use simplex::transaction::partial_input::IssuanceInput;
-use simplex::transaction::{FinalTransaction, PartialInput, PartialOutput, RequiredSignature};
+use simplex::transaction::{FinalTransaction, PartialInput, PartialOutput, RequiredSignature, TxReceipt};
 
-fn make_confidential_to_bob(alice: &Signer, bob: &Signer, asset: AssetId) -> anyhow::Result<Txid> {
+fn make_confidential_to_bob<'a>(alice: &'a Signer, bob: &Signer, asset: AssetId) -> anyhow::Result<TxReceipt<'a>> {
     let mut ft = FinalTransaction::new();
 
     ft.add_output(
@@ -12,13 +12,13 @@ fn make_confidential_to_bob(alice: &Signer, bob: &Signer, asset: AssetId) -> any
             .with_blinding_key(bob.get_blinding_public_key()),
     );
 
-    let txid = alice.broadcast(&ft)?;
-    println!("Broadcast: {}", txid);
+    let tx_receipt = alice.broadcast(&ft)?;
+    println!("Broadcast: {}", tx_receipt);
 
-    Ok(txid)
+    Ok(tx_receipt)
 }
 
-fn issue_confidential_to_alice(alice: &Signer, bob: &Signer) -> anyhow::Result<Txid> {
+fn issue_confidential_to_alice<'a>(alice: &Signer, bob: &'a Signer) -> anyhow::Result<TxReceipt<'a>> {
     let utxos = bob.get_utxos()?;
 
     let mut ft = FinalTransaction::new();
@@ -42,10 +42,10 @@ fn issue_confidential_to_alice(alice: &Signer, bob: &Signer) -> anyhow::Result<T
         .with_blinding_key(alice.get_blinding_public_key()),
     );
 
-    let txid = bob.broadcast(&ft)?;
-    println!("Broadcast: {}", txid);
+    let tx_receipt = bob.broadcast(&ft)?;
+    println!("Broadcast: {}", tx_receipt);
 
-    Ok(txid)
+    Ok(tx_receipt)
 }
 
 #[simplex::test]
@@ -54,21 +54,21 @@ fn confidential_test(context: simplex::TestContext) -> anyhow::Result<()> {
     let alice = context.get_default_signer();
     let bob = context.random_signer();
 
-    let txid = make_confidential_to_bob(alice, &bob, provider.get_network().policy_asset())?;
+    let tx_receipt = make_confidential_to_bob(alice, &bob, provider.get_network().policy_asset())?;
 
-    provider.wait(&txid)?;
+    tx_receipt.wait()?;
     println!("Confirmed");
 
-    let txid = issue_confidential_to_alice(alice, &bob)?;
+    let tx_receipt = issue_confidential_to_alice(alice, &bob)?;
 
-    provider.wait(&txid)?;
+    tx_receipt.wait()?;
     println!("Confirmed");
 
     // spend confidential
-    let txid = bob.send(alice.get_address().script_pubkey(), 50)?;
-    println!("Broadcast: {}", txid);
+    let tx_receipt = bob.send(alice.get_address().script_pubkey(), 50)?;
+    println!("Broadcast: {}", tx_receipt);
 
-    provider.wait(&txid)?;
+    tx_receipt.wait()?;
     println!("Confirmed");
 
     Ok(())

--- a/fixtures/tests/basic_test.rs
+++ b/fixtures/tests/basic_test.rs
@@ -24,8 +24,8 @@ fn spend_p2wpkh(context: &simplex::TestContext) -> anyhow::Result<()> {
 
     let (_, p2pk_script) = get_p2pk(context);
 
-    let txid = signer.send(p2pk_script.clone(), 50)?;
-    println!("Broadcast: {}", txid);
+    let tx_receipt = signer.send(p2pk_script.clone(), 50)?;
+    println!("Broadcast: {}", tx_receipt);
 
     Ok(())
 }
@@ -50,8 +50,8 @@ fn spend_p2pk(context: &simplex::TestContext) -> anyhow::Result<()> {
         RequiredSignature::Witness("SIGNATURE".to_string()),
     );
 
-    let txid = signer.broadcast(&ft)?;
-    println!("Broadcast: {}", txid);
+    let tx_receipt = signer.broadcast(&ft)?;
+    println!("Broadcast: {}", tx_receipt);
 
     Ok(())
 }

--- a/fixtures/tests/confidential_test.rs
+++ b/fixtures/tests/confidential_test.rs
@@ -12,8 +12,8 @@ fn make_confidential_to_bob(alice: &Signer, bob: &Signer, asset: AssetId) -> any
             .with_blinding_key(bob.get_blinding_public_key()),
     );
 
-    let txid = alice.broadcast(&ft)?;
-    println!("Broadcast: {}", txid);
+    let tx_receipt = alice.broadcast(&ft)?;
+    println!("Broadcast: {}", tx_receipt);
 
     Ok(())
 }
@@ -42,8 +42,8 @@ fn issue_confidential_to_alice(alice: &Signer, bob: &Signer) -> anyhow::Result<(
         .with_blinding_key(alice.get_blinding_public_key()),
     );
 
-    let txid = bob.broadcast(&ft)?;
-    println!("Broadcast: {}", txid);
+    let tx_receipt = bob.broadcast(&ft)?;
+    println!("Broadcast: {}", tx_receipt);
 
     Ok(())
 }
@@ -58,8 +58,8 @@ fn confidential_test(context: simplex::TestContext) -> anyhow::Result<()> {
     issue_confidential_to_alice(alice, &bob)?;
 
     // spend confidential
-    let txid = bob.send(alice.get_address().script_pubkey(), 50)?;
-    println!("Broadcast: {}", txid);
+    let tx_receipt = bob.send(alice.get_address().script_pubkey(), 50)?;
+    println!("Broadcast: {}", tx_receipt);
 
     Ok(())
 }

--- a/fixtures/tests/log_level.rs
+++ b/fixtures/tests/log_level.rs
@@ -20,8 +20,8 @@ fn dummy_log_level(context: simplex::TestContext) -> anyhow::Result<()> {
 
     let (dummy, script) = setup_dummy(&context);
 
-    let txid = signer.send(script.clone(), 50)?;
-    println!("Funded dummy script: {}", txid);
+    let tx_receipt = signer.send(script.clone(), 50)?;
+    println!("Funded dummy script: {}", tx_receipt);
 
     let utxos = provider.fetch_scripthash_utxos(&script)?;
 

--- a/fixtures/tests/nested_sig.rs
+++ b/fixtures/tests/nested_sig.rs
@@ -22,8 +22,8 @@ fn fund_nested_sig(context: &simplex::TestContext) -> anyhow::Result<()> {
     let signer = context.get_default_signer();
     let (_, script) = get_nested_sig(context);
 
-    let txid = signer.send(script, 50_000)?;
-    println!("Funded: {}", txid);
+    let tx_receipt = signer.send(script, 50_000)?;
+    println!("Funded: {}", tx_receipt);
 
     Ok(())
 }
@@ -48,8 +48,8 @@ fn spend_nested_sig(
         RequiredSignature::witness_with_path("INHERIT_OR_NOT", sig_path),
     );
 
-    let txid = signer.broadcast(&ft)?;
-    println!("Broadcast: {}", txid);
+    let tx_receipt = signer.broadcast(&ft)?;
+    println!("Broadcast: {}", tx_receipt);
 
     Ok(())
 }

--- a/fixtures/tests/reissuance_test.rs
+++ b/fixtures/tests/reissuance_test.rs
@@ -1,10 +1,12 @@
-use simplex::simplicityhl::elements::{AssetId, Txid};
+use simplex::simplicityhl::elements::AssetId;
 
 use simplex::signer::Signer;
 use simplex::transaction::partial_input::IssuanceInput;
-use simplex::transaction::{FinalTransaction, IssuanceDetails, PartialInput, PartialOutput, RequiredSignature};
+use simplex::transaction::{
+    FinalTransaction, IssuanceDetails, PartialInput, PartialOutput, RequiredSignature, TxReceipt,
+};
 
-fn make_confidential_to_bob(alice: &Signer, bob: &Signer, asset: AssetId) -> anyhow::Result<Txid> {
+fn make_confidential_to_bob<'a>(alice: &'a Signer, bob: &Signer, asset: AssetId) -> anyhow::Result<TxReceipt<'a>> {
     let mut ft = FinalTransaction::new();
 
     ft.add_output(
@@ -12,13 +14,16 @@ fn make_confidential_to_bob(alice: &Signer, bob: &Signer, asset: AssetId) -> any
             .with_blinding_key(bob.get_blinding_public_key()),
     );
 
-    let txid = alice.broadcast(&ft)?;
-    println!("Broadcast: {}", txid);
+    let tx_receipt = alice.broadcast(&ft)?;
+    println!("Broadcast: {}", tx_receipt);
 
-    Ok(txid)
+    Ok(tx_receipt)
 }
 
-fn issue_explicit_to_alice_with_reissuance(alice: &Signer, bob: &Signer) -> anyhow::Result<(Txid, IssuanceDetails)> {
+fn issue_explicit_to_alice_with_reissuance<'a>(
+    alice: &Signer,
+    bob: &'a Signer,
+) -> anyhow::Result<(TxReceipt<'a>, IssuanceDetails)> {
     let utxos = bob.get_utxos()?;
 
     let mut ft = FinalTransaction::new();
@@ -43,17 +48,17 @@ fn issue_explicit_to_alice_with_reissuance(alice: &Signer, bob: &Signer) -> anyh
         .with_blinding_key(bob.get_blinding_public_key()),
     );
 
-    let txid = bob.broadcast(&ft)?;
-    println!("Broadcast: {}", txid);
+    let tx_receipt = bob.broadcast(&ft)?;
+    println!("Broadcast: {}", tx_receipt);
 
-    Ok((txid, issuance_details))
+    Ok((tx_receipt, issuance_details))
 }
 
-fn reissue_tokens_to_bob(
-    bob: &Signer,
+fn reissue_tokens_to_bob<'a>(
+    bob: &'a Signer,
     issuance_details: &IssuanceDetails,
     reissuance_amount: u64,
-) -> anyhow::Result<Txid> {
+) -> anyhow::Result<TxReceipt<'a>> {
     let reissuance_token_utxo = bob.get_utxos_asset(issuance_details.inflation_asset_id)?[0].clone();
 
     let mut ft = FinalTransaction::new();
@@ -79,10 +84,10 @@ fn reissue_tokens_to_bob(
         issuance_details.asset_id,
     ));
 
-    let txid = bob.broadcast(&ft)?;
-    println!("Broadcast: {}", txid);
+    let tx_receipt = bob.broadcast(&ft)?;
+    println!("Broadcast: {}", tx_receipt);
 
-    Ok(txid)
+    Ok(tx_receipt)
 }
 
 #[simplex::test]
@@ -91,21 +96,21 @@ fn reissuance_test(context: simplex::TestContext) -> anyhow::Result<()> {
     let alice = context.get_default_signer();
     let bob = context.random_signer();
 
-    let txid = make_confidential_to_bob(alice, &bob, provider.get_network().policy_asset())?;
+    let tx_receipt = make_confidential_to_bob(alice, &bob, provider.get_network().policy_asset())?;
 
-    provider.wait(&txid)?;
+    tx_receipt.wait()?;
     println!("Confirmed");
 
-    let (txid, issuance_details) = issue_explicit_to_alice_with_reissuance(alice, &bob)?;
+    let (tx_receipt, issuance_details) = issue_explicit_to_alice_with_reissuance(alice, &bob)?;
 
-    provider.wait(&txid)?;
+    tx_receipt.wait()?;
     println!("Confirmed");
 
     let reissuance_amount = 5000;
-    let txid = reissue_tokens_to_bob(&bob, &issuance_details, reissuance_amount)?;
-    println!("Broadcast: {}", txid);
+    let tx_receipt = reissue_tokens_to_bob(&bob, &issuance_details, reissuance_amount)?;
+    println!("Broadcast: {}", tx_receipt);
 
-    provider.wait(&txid)?;
+    tx_receipt.wait()?;
     println!("Confirmed");
 
     let bob_asset_utxos = bob.get_utxos_asset(issuance_details.asset_id)?;


### PR DESCRIPTION
<!-- 
Thank you for contributing to Simplex! 

Before opening a pull request, please check out the contributing guidelines.

Make sure that the CHANGELOG.md is up to date and starts with the following header:

```
# Changelog

## [<version>|Unreleased]

- <Pull request changes description>.
```

Also consider ticking the relevant statements below.
-->

- [ ] This PR suggests a **bug fix** and I've added the necessary tests.
- [x] This PR introduces a **new feature** and I've discussed the update in an Issue or with the team.
- [ ] This PR is just a **minor change** like a typo fix.

---

<!-- Add the PR description here. -->

- add simplex::transaction::TxReceipt type to wrap behaviour over Txid. In this way, we need to wait for Txid to complete instead of invoking the provider
- function to wait for elements::Txid remained in place
- align tests

Now, interaction with the interface is changed in the following way.
Before:
```rust 
let txid = alice.broadcast(&ft)?;
provider.wait(&txid)?;
```
After:
```rust
let tx_receipt = alice.broadcast(&ft)?;
tx_receipt.wait()?;
```

Needless to mention, that precious behaviour remained for compatibility.