### PR TITLE
smplx_sdk: add wrapper over Transaction for fetch_transaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 ![](https://github.com/user-attachments/assets/c4661df7-6101-4c46-9376-dedaeef8056b)
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Tests](https://github.com/BlockstreamResearch/smplx/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/BlockstreamResearch/smplx/workflows/ci.yml)
+[![Tests](https://github.com/BlockstreamResearch/smplx/actions/workflows/crates.yml/badge.svg?branch=master)](https://github.com/BlockstreamResearch/smplx/workflows/crates.yml)
+[![Integration](https://github.com/BlockstreamResearch/smplx/actions/workflows/fixtures.yml/badge.svg?branch=master)](https://github.com/BlockstreamResearch/smplx/workflows/fixtures.yml)
 [![Community](https://img.shields.io/endpoint?color=neon&logo=telegram&label=Chat&url=https%3A%2F%2Ftg.sumanjay.workers.dev%2Fsimplicity_community)](https://t.me/simplicity_community)
 
 # Smplx

--- a/crates/sdk/src/provider/core.rs
+++ b/crates/sdk/src/provider/core.rs
@@ -5,7 +5,7 @@ use electrsd::bitcoind::bitcoincore_rpc::Auth;
 use simplicityhl::elements::{Address, Script, Transaction, Txid};
 
 use crate::provider::SimplicityNetwork;
-use crate::transaction::UTXO;
+use crate::transaction::{Transaction as SmplxTransaction, UTXO};
 
 use super::error::ProviderError;
 
@@ -30,7 +30,7 @@ pub trait ProviderTrait {
 
     fn fetch_tip_timestamp(&self) -> Result<u64, ProviderError>;
 
-    fn fetch_transaction(&self, txid: &Txid) -> Result<Transaction, ProviderError>;
+    fn fetch_transaction(&self, txid: &Txid) -> Result<SmplxTransaction, ProviderError>;
 
     fn fetch_address_utxos(&self, address: &Address) -> Result<Vec<UTXO>, ProviderError>;
 

--- a/crates/sdk/src/provider/esplora.rs
+++ b/crates/sdk/src/provider/esplora.rs
@@ -11,7 +11,7 @@ use simplicityhl::elements::{Address, OutPoint, Script, Transaction, Txid};
 use serde::Deserialize;
 
 use crate::provider::SimplicityNetwork;
-use crate::transaction::UTXO;
+use crate::transaction::{Transaction as SmplxTransaction, UTXO};
 
 use super::core::{DEFAULT_ESPLORA_TIMEOUT_SECS, ProviderTrait};
 use super::error::ProviderError;
@@ -89,7 +89,7 @@ impl EsploraProvider {
             .iter()
             .map(|point| UTXO {
                 outpoint: *point,
-                txout: map.get(&point.txid).unwrap().output[point.vout as usize].clone(),
+                txout: map.get(&point.txid).unwrap().as_ref().output[point.vout as usize].clone(),
                 secrets: None,
             })
             .collect())
@@ -228,7 +228,7 @@ impl ProviderTrait for EsploraProvider {
         Ok(block.timestamp)
     }
 
-    fn fetch_transaction(&self, txid: &Txid) -> Result<Transaction, ProviderError> {
+    fn fetch_transaction(&self, txid: &Txid) -> Result<SmplxTransaction, ProviderError> {
         let url = format!("{}/tx/{}/raw", self.esplora_url, txid);
         let timeout_secs = self.timeout.as_secs();
 
@@ -247,7 +247,7 @@ impl ProviderTrait for EsploraProvider {
         let bytes = response.as_bytes();
         let tx: Transaction = encode::deserialize(bytes).map_err(|e| ProviderError::Deserialize(e.to_string()))?;
 
-        Ok(tx)
+        Ok(SmplxTransaction::from(tx))
     }
 
     fn fetch_address_utxos(&self, address: &Address) -> Result<Vec<UTXO>, ProviderError> {

--- a/crates/sdk/src/provider/simplex.rs
+++ b/crates/sdk/src/provider/simplex.rs
@@ -5,7 +5,7 @@ use electrsd::bitcoind::bitcoincore_rpc::Auth;
 use simplicityhl::elements::{Address, Script, Transaction, Txid};
 
 use crate::provider::SimplicityNetwork;
-use crate::transaction::UTXO;
+use crate::transaction::{Transaction as SmplxTransaction, UTXO};
 
 use super::core::ProviderTrait;
 use super::error::ProviderError;
@@ -50,7 +50,7 @@ impl ProviderTrait for SimplexProvider {
         self.esplora.fetch_tip_timestamp()
     }
 
-    fn fetch_transaction(&self, txid: &Txid) -> Result<Transaction, ProviderError> {
+    fn fetch_transaction(&self, txid: &Txid) -> Result<SmplxTransaction, ProviderError> {
         self.esplora.fetch_transaction(txid)
     }
 

--- a/crates/sdk/src/signer/core.rs
+++ b/crates/sdk/src/signer/core.rs
@@ -337,7 +337,7 @@ impl Signer {
         PrivateKey::new(blinding_key, NetworkKind::Test)
     }
 
-    fn unblind(&self, utxos: Vec<UTXO>) -> Result<Vec<UTXO>, SignerError> {
+    pub(crate) fn unblind(&self, utxos: Vec<UTXO>) -> Result<Vec<UTXO>, SignerError> {
         let mut unblinded: Vec<UTXO> = Vec::new();
 
         for mut utxo in utxos {

--- a/crates/sdk/src/transaction/mod.rs
+++ b/crates/sdk/src/transaction/mod.rs
@@ -1,9 +1,12 @@
 pub mod final_transaction;
 pub mod partial_input;
 pub mod partial_output;
+#[allow(clippy::module_inception)]
+pub mod transaction;
 pub mod utxo;
 
 pub use final_transaction::{FinalInput, FinalTransaction};
 pub use partial_input::{PartialInput, ProgramInput, RequiredSignature};
 pub use partial_output::PartialOutput;
+pub use transaction::Transaction;
 pub use utxo::UTXO;

--- a/crates/sdk/src/transaction/transaction.rs
+++ b/crates/sdk/src/transaction/transaction.rs
@@ -1,0 +1,72 @@
+use crate::signer::{Signer, SignerError, SignerTrait};
+use crate::transaction::UTXO;
+use simplicityhl::elements;
+use simplicityhl::elements::OutPoint;
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct Transaction(elements::Transaction);
+
+#[derive(thiserror::Error, Debug)]
+pub enum TransactionError {
+    #[error("Incorrect vout index, get: {vout_index}, vouts in tx: {vout_len}")]
+    IncorrectVoutIndex { vout_index: usize, vout_len: usize },
+    #[error(transparent)]
+    SignerError(#[from] SignerError),
+}
+
+impl From<elements::Transaction> for Transaction {
+    fn from(txid: elements::Transaction) -> Self {
+        Transaction(txid)
+    }
+}
+
+impl From<Transaction> for elements::Transaction {
+    fn from(value: Transaction) -> Self {
+        value.0
+    }
+}
+
+impl AsRef<elements::Transaction> for Transaction {
+    fn as_ref(&self) -> &elements::Transaction {
+        &self.0
+    }
+}
+
+impl Transaction {
+    #[inline]
+    pub fn get_explicit_out(&self, vout: u32) -> Result<UTXO, TransactionError> {
+        self.get_utxo_out(vout)
+    }
+
+    #[inline]
+    pub fn get_unblinded_out<S: SignerTrait + ?Sized>(
+        self,
+        signer: &Signer,
+        vout: u32,
+    ) -> Result<UTXO, TransactionError> {
+        let utxo = self.get_utxo_out(vout)?;
+        Ok(signer.unblind(vec![utxo])?[0].clone())
+    }
+
+    pub fn into_inner(self) -> elements::Transaction {
+        self.0
+    }
+}
+
+impl Transaction {
+    #[inline]
+    fn get_utxo_out(&self, vout: u32) -> Result<UTXO, TransactionError> {
+        let vout_usize = vout as usize;
+        if vout_usize >= self.0.output.len() {
+            return Err(TransactionError::IncorrectVoutIndex {
+                vout_index: vout_usize,
+                vout_len: self.0.output.len(),
+            });
+        }
+        Ok(UTXO {
+            outpoint: OutPoint::new(self.0.txid(), vout),
+            txout: self.0.output[vout_usize].clone(),
+            secrets: None,
+        })
+    }
+}


### PR DESCRIPTION
<!-- 
Thank you for contributing to Simplex! 

Before opening a pull request, please check out the contributing guidelines.

Make sure that the CHANGELOG.md is up to date and starts with the following header:

```
# Changelog

## [<version>|Unreleased]

- <Pull request changes description>.
```

Also consider ticking the relevant statements below.
-->

- [ ] This PR suggests a **bug fix** and I've added the necessary tests.
- [x] This PR introduces a **new feature** and I've discussed the update in an Issue or with the team.
- [ ] This PR is just a **minor change** like a typo fix.

---

<!-- Add the PR description here. -->

- Add simplex::transaction::Transaction type to wrap behaviour over Transaction. In this way, we need to invoke get_unblinded_out or get_explicit_out to obtain a UTXO object from elements::Transaction 
- Changes code in the following way.
Before: 
```rust
let lending_utxo = provider.fetch_scripthash_utxos(&lending.get_script_pubkey())?[0].clone();

    let lending_creation_tx = provider.fetch_transaction(&lending_creation_txid)?;

    let first_parameters_nft_utxo = UTXO {
        outpoint: OutPoint::new(lending_creation_txid, 1),
        txout: lending_creation_tx.output[1].clone(),
        secrets: None,
    };
    let second_parameters_nft_utxo = UTXO {
        outpoint: OutPoint::new(lending_creation_txid, 2),
        txout: lending_creation_tx.output[2].clone(),
        secrets: None,
    };
```
After:
```rust 
let txid = finalize_and_broadcast(&context, &ft)?;
    provider.wait(&txid)?;

    let lending_utxo = provider.fetch_scripthash_utxos(&lending.get_script_pubkey())?[0].clone();

    let lending_creation_tx = provider.fetch_transaction(&lending_creation_txid)?;

    let first_parameters_nft_utxo = lending_creation_tx.get_explicit_out(1)?;
    let second_parameters_nft_utxo = lending_creation_tx.get_explicit_out(2)?;
```