### PR TITLE
Add possibility to use NetworkUtils on tests

### DIFF
--- a/crates/sdk/src/provider/rpc/elements.rs
+++ b/crates/sdk/src/provider/rpc/elements.rs
@@ -83,7 +83,7 @@ impl ElementsRpc {
         Ok(())
     }
 
-    pub fn generate_blocks(&self, block_num: u32) -> Result<(), RpcError> {
+    pub fn generate_blocks(&self, block_num: u64) -> Result<(), RpcError> {
         const METHOD: &str = "generatetoaddress";
 
         let address = self.get_new_address("")?.to_string();
@@ -108,5 +108,13 @@ impl ElementsRpc {
         )?;
 
         Ok(())
+    }
+
+    pub fn height(&self) -> Result<u64, RpcError> {
+        const METHOD: &str = "getblockcount";
+        self.inner
+            .call::<serde_json::Value>(METHOD, &[])?
+            .as_u64()
+            .ok_or_else(|| RpcError::ElementsRpcUnexpectedReturn(METHOD.into()))
     }
 }

--- a/crates/sdk/src/provider/rpc/elements.rs
+++ b/crates/sdk/src/provider/rpc/elements.rs
@@ -112,6 +112,7 @@ impl ElementsRpc {
 
     pub fn height(&self) -> Result<u64, RpcError> {
         const METHOD: &str = "getblockcount";
+
         self.inner
             .call::<serde_json::Value>(METHOD, &[])?
             .as_u64()

--- a/crates/test/src/context.rs
+++ b/crates/test/src/context.rs
@@ -6,12 +6,15 @@ use smplx_regtest::Regtest;
 use smplx_regtest::client::RegtestClient;
 
 use smplx_sdk::global::set_global_config;
-use smplx_sdk::provider::{EsploraProvider, ProviderInfo, ProviderTrait, SimplexProvider, SimplicityNetwork};
+use smplx_sdk::provider::{
+    ElementsRpc, EsploraProvider, ProviderInfo, ProviderTrait, SimplexProvider, SimplicityNetwork,
+};
 use smplx_sdk::signer::Signer;
 use smplx_sdk::utils::random_mnemonic;
 
 use crate::config::TestConfig;
 use crate::error::TestError;
+use crate::network_utils::NetworkUtils;
 
 #[allow(dead_code)]
 pub struct TestContext {
@@ -83,6 +86,22 @@ impl TestContext {
 
     pub fn get_network(&self) -> &SimplicityNetwork {
         self.signer.get_provider().get_network()
+    }
+
+    pub fn get_network_utils(&self) -> NetworkUtils {
+        let network = self.get_network();
+        assert!(
+            matches!(network, SimplicityNetwork::ElementsRegtest { policy_asset: _ }),
+            "Network utils only available in Regtest network"
+        );
+
+        let regtest_rpc = ElementsRpc::new(
+            self._provider_info.elements_url.clone().unwrap(),
+            self._provider_info.auth.clone().unwrap(),
+        )
+        .expect("Failed to create rpc client for network utils");
+        let esplora = EsploraProvider::new(self._provider_info.esplora_url.clone(), *network);
+        NetworkUtils::from_context(regtest_rpc, esplora)
     }
 
     fn setup(config: &TestConfig) -> Result<(Signer, ProviderInfo, Option<RegtestClient>), TestError> {

--- a/crates/test/src/context.rs
+++ b/crates/test/src/context.rs
@@ -89,9 +89,8 @@ impl TestContext {
     }
 
     pub fn get_network_utils(&self) -> NetworkUtils {
-        let network = self.get_network();
         assert!(
-            matches!(network, SimplicityNetwork::ElementsRegtest { policy_asset: _ }),
+            self._client.is_some(),
             "Network utils only available in Regtest network"
         );
 
@@ -100,8 +99,11 @@ impl TestContext {
             self._provider_info.auth.clone().unwrap(),
         )
         .expect("Failed to create rpc client for network utils");
+
+        let network = self.get_network();
         let esplora = EsploraProvider::new(self._provider_info.esplora_url.clone(), *network);
-        NetworkUtils::from_context(regtest_rpc, esplora)
+
+        NetworkUtils::new(regtest_rpc, esplora)
     }
 
     fn setup(config: &TestConfig) -> Result<(Signer, ProviderInfo, Option<RegtestClient>), TestError> {

--- a/crates/test/src/error.rs
+++ b/crates/test/src/error.rs
@@ -4,8 +4,6 @@ use smplx_sdk::provider::ProviderError;
 
 use smplx_regtest::error::RegtestError;
 
-use crate::network_utils::NetworkUtilsError;
-
 #[derive(thiserror::Error, Debug)]
 pub enum TestError {
     #[error(transparent)]
@@ -25,4 +23,12 @@ pub enum TestError {
 
     #[error("Occurred a network utils execution error: '{0}'")]
     NetworkUtilsExecution(#[from] NetworkUtilsError),
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum NetworkUtilsError {
+    #[error(transparent)]
+    Provider(#[from] ProviderError),
+    #[error("Unsuccessful action completion, err: '{0}'")]
+    UnsuccessfulSync(String),
 }

--- a/crates/test/src/error.rs
+++ b/crates/test/src/error.rs
@@ -29,6 +29,7 @@ pub enum TestError {
 pub enum NetworkUtilsError {
     #[error(transparent)]
     Provider(#[from] ProviderError),
+
     #[error("Unsuccessful action completion, err: '{0}'")]
     UnsuccessfulSync(String),
 }

--- a/crates/test/src/error.rs
+++ b/crates/test/src/error.rs
@@ -4,6 +4,8 @@ use smplx_sdk::provider::ProviderError;
 
 use smplx_regtest::error::RegtestError;
 
+use crate::network_utils::NetworkUtilsError;
+
 #[derive(thiserror::Error, Debug)]
 pub enum TestError {
     #[error(transparent)]
@@ -20,4 +22,7 @@ pub enum TestError {
 
     #[error("Network name should either be `Liquid`, `LiquidTestnet` or `ElementsRegtest`, got: {0}")]
     BadNetworkName(String),
+
+    #[error("Occurred a network utils execution error: '{0}'")]
+    NetworkUtilsExecution(#[from] NetworkUtilsError),
 }

--- a/crates/test/src/lib.rs
+++ b/crates/test/src/lib.rs
@@ -2,6 +2,8 @@ pub mod config;
 pub mod context;
 pub mod error;
 pub mod macros;
+pub mod network_utils;
 
 pub use config::{RpcConfig, TEST_ENV_NAME, TestConfig};
 pub use macros::core::SMPLX_TEST_MARKER;
+pub use network_utils::NetworkUtils;

--- a/crates/test/src/network_utils.rs
+++ b/crates/test/src/network_utils.rs
@@ -30,6 +30,7 @@ impl NetworkUtils {
 
                 std::thread::sleep(std::time::Duration::from_millis(100));
             }
+
             return Err(NetworkUtilsError::UnsuccessfulSync(format!(
                 "Failed to complete mining until height, got: '{h}', desired height: '{current_height}'",
             )));

--- a/crates/test/src/network_utils.rs
+++ b/crates/test/src/network_utils.rs
@@ -1,0 +1,45 @@
+use smplx_sdk::provider::{ElementsRpc, EsploraProvider, ProviderError, ProviderTrait};
+use smplx_sdk::signer::SignerError;
+
+pub struct NetworkUtils {
+    rpc: ElementsRpc,
+    esplora: EsploraProvider,
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum NetworkUtilsError {
+    #[error(transparent)]
+    Provider(#[from] ProviderError),
+    #[error(transparent)]
+    Signer(#[from] SignerError),
+}
+
+impl NetworkUtils {
+    pub fn from_context(rpc: ElementsRpc, esplora: EsploraProvider) -> Self {
+        Self { rpc, esplora }
+    }
+
+    pub fn mine_until_height(&self, target_height: u64) -> Result<(), NetworkUtilsError> {
+        self._mine_until_height(target_height)
+    }
+}
+
+impl NetworkUtils {
+    fn _mine_until_height(&self, target_height: u64) -> Result<(), NetworkUtilsError> {
+        let current_height = self.rpc.height().map_err(ProviderError::from)?;
+        if current_height < target_height {
+            let blocks_to_mine = target_height - current_height;
+            self.rpc.generate_blocks(blocks_to_mine).map_err(ProviderError::from)?;
+
+            for _ in 0..50 {
+                let h = self.esplora.fetch_tip_height()? as u64;
+                if h >= target_height {
+                    break;
+                }
+                std::thread::sleep(std::time::Duration::from_millis(100));
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/crates/test/src/network_utils.rs
+++ b/crates/test/src/network_utils.rs
@@ -1,43 +1,38 @@
 use smplx_sdk::provider::{ElementsRpc, EsploraProvider, ProviderError, ProviderTrait};
-use smplx_sdk::signer::SignerError;
+
+use crate::error::NetworkUtilsError;
 
 pub struct NetworkUtils {
     rpc: ElementsRpc,
     esplora: EsploraProvider,
 }
 
-#[derive(thiserror::Error, Debug)]
-pub enum NetworkUtilsError {
-    #[error(transparent)]
-    Provider(#[from] ProviderError),
-    #[error(transparent)]
-    Signer(#[from] SignerError),
-}
-
 impl NetworkUtils {
-    pub fn from_context(rpc: ElementsRpc, esplora: EsploraProvider) -> Self {
+    pub fn new(rpc: ElementsRpc, esplora: EsploraProvider) -> Self {
         Self { rpc, esplora }
     }
 
     pub fn mine_until_height(&self, target_height: u64) -> Result<(), NetworkUtilsError> {
-        self._mine_until_height(target_height)
-    }
-}
-
-impl NetworkUtils {
-    fn _mine_until_height(&self, target_height: u64) -> Result<(), NetworkUtilsError> {
         let current_height = self.rpc.height().map_err(ProviderError::from)?;
+
         if current_height < target_height {
             let blocks_to_mine = target_height - current_height;
+
             self.rpc.generate_blocks(blocks_to_mine).map_err(ProviderError::from)?;
 
+            let mut h = 0;
             for _ in 0..50 {
-                let h = self.esplora.fetch_tip_height()? as u64;
+                h = self.esplora.fetch_tip_height()? as u64;
+
                 if h >= target_height {
                     break;
                 }
+
                 std::thread::sleep(std::time::Duration::from_millis(100));
             }
+            return Err(NetworkUtilsError::UnsuccessfulSync(format!(
+                "Failed to complete mining until height, got: '{h}', desired height: '{current_height}'",
+            )));
         }
 
         Ok(())

--- a/fixtures/tests/hack_tests.rs
+++ b/fixtures/tests/hack_tests.rs
@@ -1,0 +1,14 @@
+#[simplex::test(regtest)]
+fn test_blocks_mining(context: simplex::TestContext) -> anyhow::Result<()> {
+    const DESIRED_HEIGHT: u64 = 1_234;
+
+    let network_utils = context.get_network_utils();
+    network_utils.mine_until_height(DESIRED_HEIGHT)?;
+
+    assert_eq!(
+        DESIRED_HEIGHT,
+        context.get_default_provider().fetch_tip_height()? as u64
+    );
+
+    Ok(())
+}

--- a/fixtures/tests/network_utils.rs
+++ b/fixtures/tests/network_utils.rs
@@ -1,4 +1,4 @@
-#[simplex::test(regtest)]
+#[simplex::test]
 fn test_blocks_mining(context: simplex::TestContext) -> anyhow::Result<()> {
     const DESIRED_HEIGHT: u64 = 1_234;
 


### PR DESCRIPTION
<!-- 
Thank you for contributing to Simplex! 

Before opening a pull request, please check out the contributing guidelines.

Make sure that the CHANGELOG.md is up to date and starts with the following header:

```
# Changelog

## [<version>|Unreleased]

- <Pull request changes description>.
```

Also consider ticking the relevant statements below.
-->

- [ ] This PR suggests a **bug fix** and I've added the necessary tests.
- [x] This PR introduces a **new feature** and I've discussed the update in an Issue or with the team.
- [ ] This PR is just a **minor change** like a typo fix.

---

<!-- Add the PR description here. -->

Introduce the possibility of creating NetworkUtils on simplex, which would simplify testing using the simplex test suite.

- add generate_blocks endpoint to ProviderTrait
- add hack function to generate desired block height in test
- add test for it
- getting NetworkUtils is available only for the Regtest network
