### PR TITLE
smplx_test: fix typo in mine_until_height when returning Err value on…

### DIFF
--- a/crates/test/src/network_utils.rs
+++ b/crates/test/src/network_utils.rs
@@ -25,7 +25,7 @@ impl NetworkUtils {
                 h = self.esplora.fetch_tip_height()? as u64;
 
                 if h >= target_height {
-                    break;
+                    return Ok(());
                 }
 
                 std::thread::sleep(std::time::Duration::from_millis(100));


### PR DESCRIPTION
<!-- 
Thank you for contributing to Simplex! 

Before opening a pull request, please check out the contributing guidelines.

Make sure that the CHANGELOG.md is up to date and starts with the following header:

```
# Changelog

## [<version>|Unreleased]

- <Pull request changes description>.
```

Also consider ticking the relevant statements below.
-->

- [ ] This PR suggests a **bug fix** and I've added the necessary tests.
- [ ] This PR introduces a **new feature** and I've discussed the update in an Issue or with the team.
- [x] This PR is just a **minor change** like a typo fix.

---

<!-- Add the PR description here. -->
* Fix mine_until_height function returning behaviour.
