### PR TITLE
add tx cost logs and fix trace duplication

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1250,8 +1250,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 [[package]]
 name = "simplicity-lang"
 version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e57bd4d84853974a212eab24ed89da54f49fbccf5e33e93bcd29f0a6591cd5"
+source = "git+https://github.com/BlockstreamResearch/rust-simplicity?tag=simplicity-lang-0.7.0#935a0abd0b86a72feedba1b117181b6bd0fc419e"
 dependencies = [
  "bitcoin",
  "bitcoin_hashes",
@@ -1267,9 +1266,8 @@ dependencies = [
 
 [[package]]
 name = "simplicity-sys"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3401ee7331f183a5458c0f5a4b3d5d00bde0fd12e2e03728c537df34efae289"
+version = "0.6.0"
+source = "git+https://github.com/BlockstreamResearch/rust-simplicity?tag=simplicity-lang-0.7.0#935a0abd0b86a72feedba1b117181b6bd0fc419e"
 dependencies = [
  "bitcoin_hashes",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,9 @@ minreq = { version = "2.14.1", features = ["https", "json-using-serde"] }
 electrsd = { version = "0.29.0", features = ["legacy"] }
 simplicityhl = { version = "0.5.0" }
 
+[patch.crates-io]
+simplicity-lang = { git = "https://github.com/BlockstreamResearch/rust-simplicity", tag = "simplicity-lang-0.7.0" }
+
 [workspace.lints.rust]
 rust_2018_idioms = "warn"
 unused_lifetimes = "warn"

--- a/crates/sdk/src/global.rs
+++ b/crates/sdk/src/global.rs
@@ -12,6 +12,47 @@ pub struct GlobalConfig {
     verbosity: Verbosity,
 }
 
+impl GlobalConfig {
+    /// Sets the global configuration for the SDK.
+    ///
+    /// This function allows setting a global configuration which includes
+    /// the logging level for `simplicity` contracts execution.
+    /// It must be called exactly once during the application's lifetime.
+    ///
+    /// # Errors
+    /// Returns an error containing the newly created `GlobalConfig` if the global configuration has already been initialized.
+    pub fn set_global_config(verbosity: Verbosity) -> Result<(), GlobalConfig> {
+        GLOBAL_CONFIG.set(GlobalConfig { verbosity })
+    }
+
+    /// Returns the default log level if `GLOBAL_CONFIG` is not initialized
+    pub fn get_log_level() -> TrackerLogLevel {
+        GLOBAL_CONFIG
+            .get()
+            .map_or(GlobalConfig::default().verbosity.tracker_log_level(), |config| {
+                config.verbosity.tracker_log_level()
+            })
+    }
+
+    /// Returns whether the global configuration includes debug symbols,
+    /// defaulting to `false` if `GLOBAL_CONFIG` is not initialized.
+    pub fn get_include_debug_symbols() -> bool {
+        GLOBAL_CONFIG
+            .get()
+            .map_or(GlobalConfig::default().verbosity.include_debug_symbols(), |config| {
+                config.verbosity.include_debug_symbols()
+            })
+    }
+
+    /// Returns `true` if the log level corresponds to [`Verbosity::MAX_VERBOSITY_LEVEL`]
+    ///
+    /// Equivalent to the `-vv` flag passed to `simplex test`.
+    #[must_use]
+    pub fn is_max_verbose() -> bool {
+        Self::get_log_level() == Verbosity::new(Verbosity::MAX_VERBOSITY_LEVEL).tracker_log_level()
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Default, Serialize, Deserialize)]
 /// An enumeration to represent the verbosity levels of the Simplicity execution logging.
 pub enum Verbosity {
@@ -53,43 +94,4 @@ impl Verbosity {
     pub fn include_debug_symbols(&self) -> bool {
         matches!(self, Verbosity::Debug | Verbosity::Trace)
     }
-}
-
-/// Sets the global configuration for the SDK.
-///
-/// This function allows setting a global configuration which includes
-/// the logging level for `simplicity` contracts execution.
-/// It must be called exactly once during the application's lifetime.
-///
-/// # Errors
-/// Returns an error containing the newly created `GlobalConfig` if the global configuration has already been initialized.
-pub fn set_global_config(verbosity: Verbosity) -> Result<(), GlobalConfig> {
-    GLOBAL_CONFIG.set(GlobalConfig { verbosity })
-}
-
-/// Returns the default log level if `GLOBAL_CONFIG` is not initialized
-pub fn get_log_level() -> TrackerLogLevel {
-    GLOBAL_CONFIG
-        .get()
-        .map_or(GlobalConfig::default().verbosity.tracker_log_level(), |config| {
-            config.verbosity.tracker_log_level()
-        })
-}
-
-/// Returns whether the global configuration includes debug symbols,
-/// defaulting to `false` if `GLOBAL_CONFIG` is not initialized.
-pub fn get_include_debug_symbols() -> bool {
-    GLOBAL_CONFIG
-        .get()
-        .map_or(GlobalConfig::default().verbosity.include_debug_symbols(), |config| {
-            config.verbosity.include_debug_symbols()
-        })
-}
-
-/// Returns `true` if the log level orresponds to [`Verbosity::MAX_VERBOSITY_LEVEL`]
-///
-/// Equivalent to the `-vv` flag passed to `simplex test`.
-#[must_use]
-pub fn is_max_verbose() -> bool {
-    get_log_level() == Verbosity::new(Verbosity::MAX_VERBOSITY_LEVEL).tracker_log_level()
 }

--- a/crates/sdk/src/global.rs
+++ b/crates/sdk/src/global.rs
@@ -1,5 +1,4 @@
-use std::fmt::Write;
-use std::{cell::RefCell, sync::OnceLock};
+use std::sync::OnceLock;
 
 use serde::{Deserialize, Serialize};
 
@@ -87,90 +86,10 @@ pub fn get_include_debug_symbols() -> bool {
         })
 }
 
-/// Returns `true` if the log level corresponds to the `-vv` flag passed to `simplex test`.
+/// Returns `true` if the log level orresponds to [`Verbosity::MAX_VERBOSITY_LEVEL`]
 ///
-/// Equivalent to [`TrackerLogLevel::Trace`] being set as the global log level.
+/// Equivalent to the `-vv` flag passed to `simplex test`.
 #[must_use]
-pub fn is_verbose() -> bool {
-    get_log_level() >= TrackerLogLevel::Trace
-}
-
-/// Helper struct for gathering info from `node.bounds()`
-pub struct CostInfo {
-    /// truncated cmr
-    pub cmr: [u8; 8],
-    /// inner value of `Cost`
-    pub cost: u32,
-    /// program size in bytes
-    pub program_size: usize,
-    /// witness size in bytes
-    pub witness_size: usize,
-}
-
-/// Global logger state for buffering program execution output.
-///
-/// Buffers are flushed to stderr only on successful transaction finalization,
-/// discarding output from intermediate estimation passes.
-pub struct GlobalLogger {
-    /// Cost metrics from the most recent program execution.
-    pub cost_info: Option<CostInfo>,
-    /// Execution trace lines in insertion order.
-    pub trace_buffer: Vec<String>,
-}
-
-thread_local! {
-    static GLOBAL_LOGGER: RefCell<GlobalLogger> = const { RefCell::new(GlobalLogger { cost_info: None, trace_buffer: Vec::new() }) };
-
-}
-
-/// Buffers a cost log entry for the given program source.
-///
-/// Overwrites any previous entry for the same source, ensuring only
-/// the most recent execution's cost is reported.
-pub fn buffer_trace_log(tracker_logs: String) {
-    GLOBAL_LOGGER.with(|logger| logger.borrow_mut().trace_buffer.push(tracker_logs));
-}
-
-/// Buffers a line of execution trace output.
-pub fn buffer_cost_log(stats: CostInfo) {
-    GLOBAL_LOGGER.with(|logger| {
-        logger.borrow_mut().cost_info = Some(stats);
-    });
-}
-/// Flushes all buffered cost and trace output to stderr, then clears buffers.
-///
-/// Call this on successful transaction finalization.
-pub fn flush_logs() {
-    GLOBAL_LOGGER.with(|logger| {
-        let logger = logger.borrow();
-
-        if let Some(cost_info) = &logger.cost_info {
-            let cmr_hex: String = cost_info.cmr.iter().fold(String::new(), |mut output, b| {
-                let _ = write!(output, "{b:02x}");
-                output
-            });
-
-            eprintln!(
-                "Program info: cmr=[{}] cost={}wu  prog={}b  witness={}b",
-                cmr_hex, cost_info.cost, cost_info.program_size, cost_info.witness_size,
-            );
-        }
-
-        if !logger.trace_buffer.is_empty() {
-            eprintln!("── trace ──────────────────");
-            for msg in &logger.trace_buffer {
-                eprintln!("{msg}");
-            }
-        }
-    });
-
-    clear_logs();
-}
-
-/// Discards all buffered output without printing.
-pub fn clear_logs() {
-    GLOBAL_LOGGER.with(|logger| {
-        logger.borrow_mut().cost_info = None;
-        logger.borrow_mut().trace_buffer.clear();
-    });
+pub fn is_max_verbose() -> bool {
+    get_log_level() == Verbosity::new(Verbosity::MAX_VERBOSITY_LEVEL).tracker_log_level()
 }

--- a/crates/sdk/src/global.rs
+++ b/crates/sdk/src/global.rs
@@ -1,4 +1,5 @@
-use std::sync::OnceLock;
+use std::fmt::Write;
+use std::{cell::RefCell, sync::OnceLock};
 
 use serde::{Deserialize, Serialize};
 
@@ -84,4 +85,92 @@ pub fn get_include_debug_symbols() -> bool {
         .map_or(GlobalConfig::default().verbosity.include_debug_symbols(), |config| {
             config.verbosity.include_debug_symbols()
         })
+}
+
+/// Returns `true` if the log level corresponds to the `-vv` flag passed to `simplex test`.
+///
+/// Equivalent to [`TrackerLogLevel::Trace`] being set as the global log level.
+#[must_use]
+pub fn is_verbose() -> bool {
+    get_log_level() >= TrackerLogLevel::Trace
+}
+
+/// Helper struct for gathering info from `node.bounds()`
+pub struct CostInfo {
+    /// truncated cmr
+    pub cmr: [u8; 8],
+    /// inner value of `Cost`
+    pub cost: u32,
+    /// program size in bytes
+    pub program_size: usize,
+    /// witness size in bytes
+    pub witness_size: usize,
+}
+
+/// Global logger state for buffering program execution output.
+///
+/// Buffers are flushed to stderr only on successful transaction finalization,
+/// discarding output from intermediate estimation passes.
+pub struct GlobalLogger {
+    /// Cost metrics from the most recent program execution.
+    pub cost_info: Option<CostInfo>,
+    /// Execution trace lines in insertion order.
+    pub trace_buffer: Vec<String>,
+}
+
+thread_local! {
+    static GLOBAL_LOGGER: RefCell<GlobalLogger> = const { RefCell::new(GlobalLogger { cost_info: None, trace_buffer: Vec::new() }) };
+
+}
+
+/// Buffers a cost log entry for the given program source.
+///
+/// Overwrites any previous entry for the same source, ensuring only
+/// the most recent execution's cost is reported.
+pub fn buffer_trace_log(tracker_logs: String) {
+    GLOBAL_LOGGER.with(|logger| logger.borrow_mut().trace_buffer.push(tracker_logs));
+}
+
+/// Buffers a line of execution trace output.
+pub fn buffer_cost_log(stats: CostInfo) {
+    GLOBAL_LOGGER.with(|logger| {
+        logger.borrow_mut().cost_info = Some(stats);
+    });
+}
+/// Flushes all buffered cost and trace output to stderr, then clears buffers.
+///
+/// Call this on successful transaction finalization.
+pub fn flush_logs() {
+    GLOBAL_LOGGER.with(|logger| {
+        let logger = logger.borrow();
+
+        if let Some(cost_info) = &logger.cost_info {
+            let cmr_hex: String = cost_info.cmr.iter().fold(String::new(), |mut output, b| {
+                let _ = write!(output, "{b:02x}");
+                output
+            });
+
+            eprintln!(
+                "Program info: cmr=[{}] cost={}wu  prog={}b  witness={}b",
+                cmr_hex, cost_info.cost, cost_info.program_size, cost_info.witness_size,
+            );
+        }
+
+        if !logger.trace_buffer.is_empty() {
+            eprintln!("── trace ──────────────────");
+            for msg in &logger.trace_buffer {
+                eprintln!("{msg}");
+            }
+        }
+    });
+
+    clear_logs();
+}
+
+/// Discards all buffered output without printing.
+pub fn clear_logs() {
+    GLOBAL_LOGGER.with(|logger| {
+        logger.borrow_mut().cost_info = None;
+        logger.borrow_mut().trace_buffer.clear();
+    });
 }

--- a/crates/sdk/src/program/core.rs
+++ b/crates/sdk/src/program/core.rs
@@ -14,9 +14,8 @@ use simplicityhl::simplicity::{BitMachine, RedeemNode, Value, leaf_version};
 use simplicityhl::tracker::{DefaultTracker, TrackerLogLevel};
 use simplicityhl::{Parameters, WitnessTypes, WitnessValues};
 
-use crate::global::{
-    CostInfo, buffer_cost_log, buffer_trace_log, clear_logs, get_include_debug_symbols, get_log_level, is_verbose,
-};
+use crate::global::{get_include_debug_symbols, get_log_level, is_max_verbose};
+use crate::program::logger::{CostInfo, buffer_cost_log, buffer_trace_log, clear_logs};
 
 use super::arguments::ArgumentsTrait;
 use super::error::ProgramError;
@@ -163,7 +162,7 @@ impl ProgramTrait for Program {
 
         // execute() is called multiple times during fee estimation; output is buffered
         // so only the final successful execution's logs are emitted to stderr.
-        let mut tracker = if is_verbose() {
+        let mut tracker = if is_max_verbose() {
             apply_buffered_log_level(DefaultTracker::new(satisfied.debug_symbols()), get_log_level())
         } else {
             DefaultTracker::new(satisfied.debug_symbols()).with_log_level(TrackerLogLevel::None)
@@ -173,7 +172,7 @@ impl ProgramTrait for Program {
 
         let pruned = satisfied.redeem().prune_with_tracker(&env, &mut tracker)?;
 
-        if is_verbose() {
+        if is_max_verbose() {
             let bounds = pruned.bounds();
             // FIXME: Cost has no public accessor; remove once as_milliweight() is upstreamed
             let mw: u32 = unsafe { std::mem::transmute(bounds.cost) };

--- a/crates/sdk/src/program/core.rs
+++ b/crates/sdk/src/program/core.rs
@@ -1,4 +1,3 @@
-use std::fmt::Write;
 use std::iter;
 use std::sync::Arc;
 
@@ -11,11 +10,10 @@ use simplicityhl::simplicity::bitcoin::{XOnlyPublicKey, secp256k1};
 use simplicityhl::simplicity::jet::Elements;
 use simplicityhl::simplicity::jet::elements::{ElementsEnv, ElementsUtxo};
 use simplicityhl::simplicity::{BitMachine, RedeemNode, Value, leaf_version};
-use simplicityhl::tracker::{DefaultTracker, TrackerLogLevel};
 use simplicityhl::{Parameters, WitnessTypes, WitnessValues};
 
-use crate::global::{get_include_debug_symbols, get_log_level, is_max_verbose};
-use crate::program::logger::{CostInfo, buffer_cost_log, buffer_trace_log, clear_logs};
+use crate::global::GlobalConfig;
+use crate::program::logger::ProgramLogger;
 
 use super::arguments::ArgumentsTrait;
 use super::error::ProgramError;
@@ -158,34 +156,16 @@ impl ProgramTrait for Program {
             .satisfy(witness.clone())
             .map_err(ProgramError::WitnessSatisfaction)?;
 
-        clear_logs();
-
         // execute() is called multiple times during fee estimation; output is buffered
         // so only the final successful execution's logs are emitted to stderr.
-        let mut tracker = if is_max_verbose() {
-            apply_buffered_log_level(DefaultTracker::new(satisfied.debug_symbols()), get_log_level())
-        } else {
-            DefaultTracker::new(satisfied.debug_symbols()).with_log_level(TrackerLogLevel::None)
-        };
+        let mut tracker = ProgramLogger::make_tracker(satisfied.debug_symbols(), GlobalConfig::get_log_level());
 
         let env = self.get_env(pst, input_index, network)?;
 
         let pruned = satisfied.redeem().prune_with_tracker(&env, &mut tracker)?;
 
-        if is_max_verbose() {
-            let bounds = pruned.bounds();
-            // FIXME: Cost has no public accessor; remove once as_milliweight() is upstreamed
-            let mw: u32 = unsafe { std::mem::transmute(bounds.cost) };
-            let encoded = pruned.to_vec_with_witness();
-            let (program_size, witness_size) = (encoded.0.len(), encoded.1.len());
-            let cmr_bytes = pruned.cmr().to_byte_array();
-
-            buffer_cost_log(CostInfo {
-                cmr: std::array::from_fn(|i| cmr_bytes[i]),
-                cost: mw / 1000,
-                program_size,
-                witness_size,
-            });
+        if GlobalConfig::is_max_verbose() {
+            ProgramLogger::buffer_cost_log(&pruned);
         }
 
         let mut mac = BitMachine::for_program(&pruned)?;
@@ -213,50 +193,6 @@ impl ProgramTrait for Program {
             cmr.as_ref().to_vec(),
             self.control_block()?.serialize(),
         ])
-    }
-}
-
-/// Mirrors logic of `tracker::with_log_level()` for custom sink
-fn apply_buffered_log_level(tracker: DefaultTracker<'_>, log_level: TrackerLogLevel) -> DefaultTracker<'_> {
-    let tracker = if log_level >= TrackerLogLevel::Debug {
-        tracker.with_debug_sink(|label, value| {
-            buffer_trace_log(format!("  DBG: {label} = {value}"));
-        })
-    } else {
-        tracker
-    };
-
-    let tracker = if log_level >= TrackerLogLevel::Warning {
-        tracker.with_warning_sink(|msg| {
-            buffer_trace_log(format!("  WARN: {msg}"));
-        })
-    } else {
-        tracker
-    };
-
-    if log_level >= TrackerLogLevel::Trace {
-        tracker.with_jet_trace_sink(|jet, args, result| {
-            let mut msg = format!("  {jet:?}(");
-            if let Some(args) = args {
-                for (i, arg) in args.iter().enumerate() {
-                    if i > 0 {
-                        msg.push_str(", ");
-                    }
-                    let _ = write!(msg, "{arg}");
-                }
-            } else {
-                msg.push_str("...");
-            }
-            match result {
-                Some(value) => {
-                    let _ = write!(msg, ") = {value}");
-                }
-                None => msg.push_str(") -> [failed]"),
-            }
-            buffer_trace_log(msg);
-        })
-    } else {
-        tracker
     }
 }
 
@@ -375,7 +311,7 @@ impl Program {
         let compiled = CompiledProgram::new(
             self.source,
             self.arguments.build_arguments(),
-            get_include_debug_symbols(),
+            GlobalConfig::get_include_debug_symbols(),
         )
         .map_err(ProgramError::Compilation)?;
 

--- a/crates/sdk/src/program/core.rs
+++ b/crates/sdk/src/program/core.rs
@@ -1,3 +1,4 @@
+use std::fmt::Write;
 use std::iter;
 use std::sync::Arc;
 
@@ -10,10 +11,12 @@ use simplicityhl::simplicity::bitcoin::{XOnlyPublicKey, secp256k1};
 use simplicityhl::simplicity::jet::Elements;
 use simplicityhl::simplicity::jet::elements::{ElementsEnv, ElementsUtxo};
 use simplicityhl::simplicity::{BitMachine, RedeemNode, Value, leaf_version};
-use simplicityhl::tracker::DefaultTracker;
+use simplicityhl::tracker::{DefaultTracker, TrackerLogLevel};
 use simplicityhl::{Parameters, WitnessTypes, WitnessValues};
 
-use crate::global::{get_include_debug_symbols, get_log_level};
+use crate::global::{
+    CostInfo, buffer_cost_log, buffer_trace_log, clear_logs, get_include_debug_symbols, get_log_level, is_verbose,
+};
 
 use super::arguments::ArgumentsTrait;
 use super::error::ProgramError;
@@ -156,11 +159,36 @@ impl ProgramTrait for Program {
             .satisfy(witness.clone())
             .map_err(ProgramError::WitnessSatisfaction)?;
 
-        let mut tracker = DefaultTracker::new(satisfied.debug_symbols()).with_log_level(get_log_level());
+        clear_logs();
+
+        // execute() is called multiple times during fee estimation; output is buffered
+        // so only the final successful execution's logs are emitted to stderr.
+        let mut tracker = if is_verbose() {
+            apply_buffered_log_level(DefaultTracker::new(satisfied.debug_symbols()), get_log_level())
+        } else {
+            DefaultTracker::new(satisfied.debug_symbols()).with_log_level(TrackerLogLevel::None)
+        };
 
         let env = self.get_env(pst, input_index, network)?;
 
         let pruned = satisfied.redeem().prune_with_tracker(&env, &mut tracker)?;
+
+        if is_verbose() {
+            let bounds = pruned.bounds();
+            // FIXME: Cost has no public accessor; remove once as_milliweight() is upstreamed
+            let mw: u32 = unsafe { std::mem::transmute(bounds.cost) };
+            let encoded = pruned.to_vec_with_witness();
+            let (program_size, witness_size) = (encoded.0.len(), encoded.1.len());
+            let cmr_bytes = pruned.cmr().to_byte_array();
+
+            buffer_cost_log(CostInfo {
+                cmr: std::array::from_fn(|i| cmr_bytes[i]),
+                cost: mw / 1000,
+                program_size,
+                witness_size,
+            });
+        }
+
         let mut mac = BitMachine::for_program(&pruned)?;
 
         let result = mac.exec(&pruned, &env)?;
@@ -186,6 +214,50 @@ impl ProgramTrait for Program {
             cmr.as_ref().to_vec(),
             self.control_block()?.serialize(),
         ])
+    }
+}
+
+/// Mirrors logic of `tracker::with_log_level()` for custom sink
+fn apply_buffered_log_level(tracker: DefaultTracker<'_>, log_level: TrackerLogLevel) -> DefaultTracker<'_> {
+    let tracker = if log_level >= TrackerLogLevel::Debug {
+        tracker.with_debug_sink(|label, value| {
+            buffer_trace_log(format!("  DBG: {label} = {value}"));
+        })
+    } else {
+        tracker
+    };
+
+    let tracker = if log_level >= TrackerLogLevel::Warning {
+        tracker.with_warning_sink(|msg| {
+            buffer_trace_log(format!("  WARN: {msg}"));
+        })
+    } else {
+        tracker
+    };
+
+    if log_level >= TrackerLogLevel::Trace {
+        tracker.with_jet_trace_sink(|jet, args, result| {
+            let mut msg = format!("  {jet:?}(");
+            if let Some(args) = args {
+                for (i, arg) in args.iter().enumerate() {
+                    if i > 0 {
+                        msg.push_str(", ");
+                    }
+                    let _ = write!(msg, "{arg}");
+                }
+            } else {
+                msg.push_str("...");
+            }
+            match result {
+                Some(value) => {
+                    let _ = write!(msg, ") = {value}");
+                }
+                None => msg.push_str(") -> [failed]"),
+            }
+            buffer_trace_log(msg);
+        })
+    } else {
+        tracker
     }
 }
 

--- a/crates/sdk/src/program/logger.rs
+++ b/crates/sdk/src/program/logger.rs
@@ -143,11 +143,13 @@ impl ProgramLogger {
             }
 
             if !logger.trace_buffer.is_empty() {
-                eprintln!("── trace ──────────────────");
+                eprintln!("───────────── trace ─────────────");
 
                 for msg in &logger.trace_buffer {
                     eprintln!("{msg}");
                 }
+
+                eprintln!();
             }
         });
 

--- a/crates/sdk/src/program/logger.rs
+++ b/crates/sdk/src/program/logger.rs
@@ -1,0 +1,83 @@
+use std::{cell::RefCell, fmt::Write};
+/// Helper struct for gathering info from `node.bounds()`
+pub struct CostInfo {
+    /// truncated cmr
+    pub cmr: [u8; 8],
+    /// inner value of `Cost`
+    pub cost: u32,
+    /// program size in bytes
+    pub program_size: usize,
+    /// witness size in bytes
+    pub witness_size: usize,
+}
+
+/// Logger state for buffering program execution output.
+///
+/// Buffers are flushed to stderr only on successful transaction finalization,
+/// discarding output from intermediate estimation passes.
+pub struct ProgramLogger {
+    /// Cost metrics from the most recent program execution.
+    cost_info: Option<CostInfo>,
+    /// Execution trace lines in insertion order.
+    trace_buffer: Vec<String>,
+}
+
+thread_local! {
+    static PROGRAM_LOGGER: RefCell<ProgramLogger> = const { RefCell::new(ProgramLogger { cost_info: None, trace_buffer: Vec::new() }) };
+
+}
+
+/// Buffers a line of execution trace output.
+pub fn buffer_trace_log(tracker_logs: String) {
+    PROGRAM_LOGGER.with(|logger| logger.borrow_mut().trace_buffer.push(tracker_logs));
+}
+
+/// Buffers a cost log entry for the given program source.
+///
+/// Overwrites any previous entry for the same source, ensuring only
+/// the most recent execution's cost is reported.
+pub fn buffer_cost_log(stats: CostInfo) {
+    PROGRAM_LOGGER.with(|logger| {
+        logger.borrow_mut().cost_info = Some(stats);
+    });
+}
+/// Flushes all buffered cost and trace output to stderr, then clears buffers.
+///
+/// Cost metrics are printed first, followed by execution trace lines in
+/// insertion order.
+///
+/// Call this on successful transaction finalization.
+pub fn flush_logs() {
+    PROGRAM_LOGGER.with(|logger| {
+        let logger = logger.borrow();
+
+        if let Some(cost_info) = &logger.cost_info {
+            let cmr_hex: String = cost_info.cmr.iter().fold(String::new(), |mut output, b| {
+                let _ = write!(output, "{b:02x}");
+                output
+            });
+
+            eprintln!(
+                "Program info: cmr=[{}] cost={}wu  prog={}b  witness={}b",
+                cmr_hex, cost_info.cost, cost_info.program_size, cost_info.witness_size,
+            );
+        }
+
+        if !logger.trace_buffer.is_empty() {
+            eprintln!("── trace ──────────────────");
+            for msg in &logger.trace_buffer {
+                eprintln!("{msg}");
+            }
+        }
+    });
+
+    clear_logs();
+}
+
+/// Discards all buffered output without printing.
+pub fn clear_logs() {
+    PROGRAM_LOGGER.with(|logger| {
+        logger.borrow_mut().cost_info = None;
+        logger.borrow_mut().trace_buffer.clear();
+    });
+}

--- a/crates/sdk/src/program/logger.rs
+++ b/crates/sdk/src/program/logger.rs
@@ -1,6 +1,20 @@
 use std::{cell::RefCell, fmt::Write};
-/// Helper struct for gathering info from `node.bounds()`
-pub struct CostInfo {
+
+use simplicityhl::{
+    debug::DebugSymbols,
+    simplicity::{
+        jet::Jet,
+        node::{Node, Redeem},
+    },
+    tracker::{DefaultTracker, TrackerLogLevel},
+};
+
+thread_local! {
+    pub(super) static PROGRAM_LOGGER: RefCell<ProgramLogger> = const { RefCell::new(ProgramLogger { cost_info: None, trace_buffer: Vec::new() }) };
+}
+
+/// Helper struct for gathering info from `node.bounds()`.
+struct CostInfo {
     /// truncated cmr
     pub cmr: [u8; 8],
     /// inner value of `Cost`
@@ -22,62 +36,129 @@ pub struct ProgramLogger {
     trace_buffer: Vec<String>,
 }
 
-thread_local! {
-    static PROGRAM_LOGGER: RefCell<ProgramLogger> = const { RefCell::new(ProgramLogger { cost_info: None, trace_buffer: Vec::new() }) };
+impl ProgramLogger {
+    /// Mirrors [`DefaultTracker::with_log_level`] with buffered sinks instead of stderr.
+    /// Clears any previously buffered logs before configuring the tracker.
+    #[must_use]
+    pub fn make_tracker(debug_symbols: &DebugSymbols, log_level: TrackerLogLevel) -> DefaultTracker<'_> {
+        Self::clear_logs();
 
-}
+        let tracker = DefaultTracker::new(debug_symbols);
 
-/// Buffers a line of execution trace output.
-pub fn buffer_trace_log(tracker_logs: String) {
-    PROGRAM_LOGGER.with(|logger| logger.borrow_mut().trace_buffer.push(tracker_logs));
-}
+        let tracker = if log_level >= TrackerLogLevel::Debug {
+            tracker.with_debug_sink(|label, value| {
+                Self::buffer_trace_log(format!("  DBG: {label} = {value}"));
+            })
+        } else {
+            tracker
+        };
 
-/// Buffers a cost log entry for the given program source.
-///
-/// Overwrites any previous entry for the same source, ensuring only
-/// the most recent execution's cost is reported.
-pub fn buffer_cost_log(stats: CostInfo) {
-    PROGRAM_LOGGER.with(|logger| {
-        logger.borrow_mut().cost_info = Some(stats);
-    });
-}
-/// Flushes all buffered cost and trace output to stderr, then clears buffers.
-///
-/// Cost metrics are printed first, followed by execution trace lines in
-/// insertion order.
-///
-/// Call this on successful transaction finalization.
-pub fn flush_logs() {
-    PROGRAM_LOGGER.with(|logger| {
-        let logger = logger.borrow();
+        let tracker = if log_level >= TrackerLogLevel::Warning {
+            tracker.with_warning_sink(|msg| {
+                Self::buffer_trace_log(format!("  WARN: {msg}"));
+            })
+        } else {
+            tracker
+        };
 
-        if let Some(cost_info) = &logger.cost_info {
-            let cmr_hex: String = cost_info.cmr.iter().fold(String::new(), |mut output, b| {
-                let _ = write!(output, "{b:02x}");
-                output
+        if log_level >= TrackerLogLevel::Trace {
+            tracker.with_jet_trace_sink(|jet, args, result| {
+                let mut msg = format!("  {jet:?}(");
+
+                if let Some(args) = args {
+                    for (i, arg) in args.iter().enumerate() {
+                        if i > 0 {
+                            msg.push_str(", ");
+                        }
+                        let _ = write!(msg, "{arg}");
+                    }
+                } else {
+                    msg.push_str("...");
+                }
+
+                match result {
+                    Some(value) => {
+                        let _ = write!(msg, ") = {value}");
+                    }
+                    None => msg.push_str(") -> [failed]"),
+                }
+
+                Self::buffer_trace_log(msg);
+            })
+        } else {
+            tracker
+        }
+    }
+
+    /// Buffers a line of execution trace output.
+    pub fn buffer_trace_log(tracker_logs: String) {
+        PROGRAM_LOGGER.with(|logger| logger.borrow_mut().trace_buffer.push(tracker_logs));
+    }
+
+    /// Extracts and buffers cost metrics from the given redeem node.
+    ///
+    /// Overwrites any previously buffered cost info.
+    ///
+    /// # Safety
+    /// Uses `transmute` to extract the inner `u32` from [`Cost`] since no public
+    /// accessor exists. Remove once `as_milliweight()` is upstreamed to rust-simplicity.
+    pub fn buffer_cost_log<J: Jet>(node: &Node<Redeem<J>>) {
+        let bounds = node.bounds();
+        // FIXME: Cost has no public accessor; remove once as_milliweight() is upstreamed
+        let mw: u32 = unsafe { std::mem::transmute(bounds.cost) };
+        let encoded = node.to_vec_with_witness();
+        let (program_size, witness_size) = (encoded.0.len(), encoded.1.len());
+        let cmr_bytes = node.cmr().to_byte_array();
+
+        PROGRAM_LOGGER.with(|logger| {
+            logger.borrow_mut().cost_info = Some(CostInfo {
+                cmr: std::array::from_fn(|i| cmr_bytes[i]),
+                cost: mw / 1000,
+                program_size,
+                witness_size,
             });
+        });
+    }
 
-            eprintln!(
-                "Program info: cmr=[{}] cost={}wu  prog={}b  witness={}b",
-                cmr_hex, cost_info.cost, cost_info.program_size, cost_info.witness_size,
-            );
-        }
+    /// Flushes all buffered cost and trace output to stderr, then clears buffers.
+    ///
+    /// Cost metrics are printed first, followed by execution trace lines in
+    /// insertion order.
+    ///
+    /// Call this on successful transaction finalization.
+    pub fn flush_logs() {
+        PROGRAM_LOGGER.with(|logger| {
+            let logger = logger.borrow();
 
-        if !logger.trace_buffer.is_empty() {
-            eprintln!("── trace ──────────────────");
-            for msg in &logger.trace_buffer {
-                eprintln!("{msg}");
+            if let Some(cost_info) = &logger.cost_info {
+                let cmr_hex: String = cost_info.cmr.iter().fold(String::new(), |mut output, b| {
+                    let _ = write!(output, "{b:02x}");
+                    output
+                });
+
+                eprintln!(
+                    "Program info: cmr=[{}] cost={}wu  prog={}b  witness={}b",
+                    cmr_hex, cost_info.cost, cost_info.program_size, cost_info.witness_size,
+                );
             }
-        }
-    });
 
-    clear_logs();
-}
+            if !logger.trace_buffer.is_empty() {
+                eprintln!("── trace ──────────────────");
 
-/// Discards all buffered output without printing.
-pub fn clear_logs() {
-    PROGRAM_LOGGER.with(|logger| {
-        logger.borrow_mut().cost_info = None;
-        logger.borrow_mut().trace_buffer.clear();
-    });
+                for msg in &logger.trace_buffer {
+                    eprintln!("{msg}");
+                }
+            }
+        });
+
+        Self::clear_logs();
+    }
+
+    /// Discards all buffered output without printing.
+    pub fn clear_logs() {
+        PROGRAM_LOGGER.with(|logger| {
+            logger.borrow_mut().cost_info = None;
+            logger.borrow_mut().trace_buffer.clear();
+        });
+    }
 }

--- a/crates/sdk/src/program/mod.rs
+++ b/crates/sdk/src/program/mod.rs
@@ -4,6 +4,8 @@ pub mod arguments;
 pub mod core;
 /// Error types and definitions for program compilation, manipulation, and execution failures.
 pub mod error;
+/// Program execution's specific logger
+pub mod logger;
 /// Definitions and traits for resolving and satisfying execution witnesses for Simplicity programs.
 pub mod witness;
 

--- a/crates/sdk/src/signer/core.rs
+++ b/crates/sdk/src/signer/core.rs
@@ -30,7 +30,7 @@ use elements_miniscript::{
 
 use crate::constants::MIN_FEE;
 use crate::program::ProgramTrait;
-use crate::program::logger::flush_logs;
+use crate::program::logger::ProgramLogger;
 use crate::provider::ProviderTrait;
 use crate::provider::SimplicityNetwork;
 use crate::signer::wtns_injector::WtnsInjector;
@@ -202,7 +202,7 @@ impl Signer {
             if policy_amount_delta >= curr_fee.cast_signed() {
                 match self.estimate_tx(fee_tx.clone(), fee_rate, policy_amount_delta.cast_unsigned())? {
                     Estimate::Success(tx, fee) => {
-                        flush_logs();
+                        ProgramLogger::flush_logs();
                         return Ok((tx, fee));
                     }
                     Estimate::Failure(required_fee) => curr_fee = required_fee,
@@ -218,7 +218,7 @@ impl Signer {
         if policy_amount_delta >= curr_fee.cast_signed() {
             match self.estimate_tx(fee_tx.clone(), fee_rate, policy_amount_delta.cast_unsigned())? {
                 Estimate::Success(tx, fee) => {
-                    flush_logs();
+                    ProgramLogger::flush_logs();
                     return Ok((tx, fee));
                 }
                 Estimate::Failure(required_fee) => curr_fee = required_fee,
@@ -249,7 +249,10 @@ impl Signer {
 
         // policy_amount_delta will be > 0
         match self.estimate_tx(tx.clone(), fee_rate, policy_amount_delta.cast_unsigned())? {
-            Estimate::Success(tx, fee) => Ok((tx, fee)),
+            Estimate::Success(tx, fee) => {
+                ProgramLogger::flush_logs();
+                Ok((tx, fee))
+            }
             Estimate::Failure(required_fee) => Err(SignerError::NotEnoughFeeAmount(policy_amount_delta, required_fee)),
         }
     }

--- a/crates/sdk/src/signer/core.rs
+++ b/crates/sdk/src/signer/core.rs
@@ -29,8 +29,8 @@ use elements_miniscript::{
 };
 
 use crate::constants::MIN_FEE;
-use crate::global::flush_logs;
 use crate::program::ProgramTrait;
+use crate::program::logger::flush_logs;
 use crate::provider::ProviderTrait;
 use crate::provider::SimplicityNetwork;
 use crate::signer::wtns_injector::WtnsInjector;

--- a/crates/sdk/src/signer/core.rs
+++ b/crates/sdk/src/signer/core.rs
@@ -29,6 +29,7 @@ use elements_miniscript::{
 };
 
 use crate::constants::MIN_FEE;
+use crate::global::flush_logs;
 use crate::program::ProgramTrait;
 use crate::provider::ProviderTrait;
 use crate::provider::SimplicityNetwork;
@@ -200,7 +201,10 @@ impl Signer {
 
             if policy_amount_delta >= curr_fee.cast_signed() {
                 match self.estimate_tx(fee_tx.clone(), fee_rate, policy_amount_delta.cast_unsigned())? {
-                    Estimate::Success(tx, fee) => return Ok((tx, fee)),
+                    Estimate::Success(tx, fee) => {
+                        flush_logs();
+                        return Ok((tx, fee));
+                    }
                     Estimate::Failure(required_fee) => curr_fee = required_fee,
                 }
             }
@@ -213,7 +217,10 @@ impl Signer {
 
         if policy_amount_delta >= curr_fee.cast_signed() {
             match self.estimate_tx(fee_tx.clone(), fee_rate, policy_amount_delta.cast_unsigned())? {
-                Estimate::Success(tx, fee) => return Ok((tx, fee)),
+                Estimate::Success(tx, fee) => {
+                    flush_logs();
+                    return Ok((tx, fee));
+                }
                 Estimate::Failure(required_fee) => curr_fee = required_fee,
             }
         }

--- a/crates/test/src/context.rs
+++ b/crates/test/src/context.rs
@@ -5,7 +5,7 @@ use electrsd::bitcoind::bitcoincore_rpc::Auth;
 use smplx_regtest::Regtest;
 use smplx_regtest::client::RegtestClient;
 
-use smplx_sdk::global::set_global_config;
+use smplx_sdk::global::GlobalConfig;
 use smplx_sdk::provider::{
     ElementsRpc, EsploraProvider, ProviderInfo, ProviderTrait, SimplexProvider, SimplicityNetwork,
 };
@@ -30,7 +30,7 @@ impl TestContext {
         let config = TestConfig::from_file(&config_path)?;
 
         // error is ignored because we assume that all tests use the same verbosity
-        let _ = set_global_config(config.verbosity);
+        let _ = GlobalConfig::set_global_config(config.verbosity);
 
         let (signer, provider_info, client) = Self::setup(&config)?;
 


### PR DESCRIPTION
## Changes 

Added logging of program cost/size info from `RedeemNode::bounds()`, fixed log duplication caused by `program::execute()` being called multiple times during fee estimation.