### PR TITLE
Add HDKeyOrigin and SIngleKeyOrigin for Signer

### DIFF
--- a/crates/regtest/src/error.rs
+++ b/crates/regtest/src/error.rs
@@ -2,6 +2,7 @@ use std::io;
 
 use smplx_sdk::provider::RpcError;
 use smplx_sdk::signer::SignerError;
+use smplx_sdk::signer::error::KeyOriginError;
 
 #[derive(thiserror::Error, Debug)]
 pub enum RegtestError {
@@ -10,6 +11,9 @@ pub enum RegtestError {
 
     #[error(transparent)]
     Signer(#[from] SignerError),
+
+    #[error(transparent)]
+    KeyOrigin(#[from] KeyOriginError),
 
     #[error("Failed to terminate elements")]
     ElementsTermination(),

--- a/crates/regtest/src/regtest.rs
+++ b/crates/regtest/src/regtest.rs
@@ -3,8 +3,7 @@ use std::time::Duration;
 use smplx_sdk::provider::ElementsRpc;
 use smplx_sdk::provider::SimplexProvider;
 use smplx_sdk::provider::SimplicityNetwork;
-use smplx_sdk::signer::core::HDKey;
-use smplx_sdk::signer::{KeyOrigin, Signer};
+use smplx_sdk::signer::{HDKey, KeyOrigin, Signer};
 use smplx_sdk::utils::btc2sat;
 
 use super::RegtestConfig;
@@ -34,8 +33,7 @@ impl Regtest {
             SimplicityNetwork::default_regtest(),
         ));
 
-        let hd_key_origin = HDKey::new(config.mnemonic.as_str())?;
-        let signer = Signer::new(hd_key_origin, provider);
+        let signer = Signer::new(HDKey::new(config.mnemonic.as_str())?, provider);
 
         Self::prepare_signer(&client, &signer, config.bitcoins)?;
 

--- a/crates/regtest/src/regtest.rs
+++ b/crates/regtest/src/regtest.rs
@@ -3,7 +3,8 @@ use std::time::Duration;
 use smplx_sdk::provider::ElementsRpc;
 use smplx_sdk::provider::SimplexProvider;
 use smplx_sdk::provider::SimplicityNetwork;
-use smplx_sdk::signer::Signer;
+use smplx_sdk::signer::core::HDKeyOrigin;
+use smplx_sdk::signer::{KeyProvider, Signer};
 use smplx_sdk::utils::btc2sat;
 
 use super::RegtestConfig;
@@ -23,7 +24,7 @@ impl Regtest {
     ///
     /// # Panics
     /// Panics if the background indexer (`electrs`) fails to index the unspent outputs within the timeout window (10 seconds).
-    pub fn from_config(config: &RegtestConfig) -> Result<(RegtestClient, Signer), RegtestError> {
+    pub fn from_config(config: &RegtestConfig) -> Result<(RegtestClient, Signer<HDKeyOrigin>), RegtestError> {
         let client = RegtestClient::new(config);
 
         let provider = Box::new(SimplexProvider::new(
@@ -33,14 +34,19 @@ impl Regtest {
             SimplicityNetwork::default_regtest(),
         ));
 
-        let signer = Signer::new(config.mnemonic.as_str(), provider);
+        let hd_key_origin = HDKeyOrigin::new(config.mnemonic.as_str())?;
+        let signer = Signer::new(hd_key_origin, provider);
 
         Self::prepare_signer(&client, &signer, config.bitcoins)?;
 
         Ok((client, signer))
     }
 
-    fn prepare_signer(client: &RegtestClient, signer: &Signer, bitcoins: u64) -> Result<(), RegtestError> {
+    fn prepare_signer<K: KeyProvider>(
+        client: &RegtestClient,
+        signer: &Signer<K>,
+        bitcoins: u64,
+    ) -> Result<(), RegtestError> {
         let rpc_provider = ElementsRpc::new(client.rpc_url(), client.auth())?;
 
         rpc_provider.generate_blocks(1)?;

--- a/crates/regtest/src/regtest.rs
+++ b/crates/regtest/src/regtest.rs
@@ -3,8 +3,8 @@ use std::time::Duration;
 use smplx_sdk::provider::ElementsRpc;
 use smplx_sdk::provider::SimplexProvider;
 use smplx_sdk::provider::SimplicityNetwork;
-use smplx_sdk::signer::core::HDKeyOrigin;
-use smplx_sdk::signer::{KeyProvider, Signer};
+use smplx_sdk::signer::core::HDKey;
+use smplx_sdk::signer::{KeyOrigin, Signer};
 use smplx_sdk::utils::btc2sat;
 
 use super::RegtestConfig;
@@ -24,7 +24,7 @@ impl Regtest {
     ///
     /// # Panics
     /// Panics if the background indexer (`electrs`) fails to index the unspent outputs within the timeout window (10 seconds).
-    pub fn from_config(config: &RegtestConfig) -> Result<(RegtestClient, Signer<HDKeyOrigin>), RegtestError> {
+    pub fn from_config(config: &RegtestConfig) -> Result<(RegtestClient, Signer<HDKey>), RegtestError> {
         let client = RegtestClient::new(config);
 
         let provider = Box::new(SimplexProvider::new(
@@ -34,7 +34,7 @@ impl Regtest {
             SimplicityNetwork::default_regtest(),
         ));
 
-        let hd_key_origin = HDKeyOrigin::new(config.mnemonic.as_str())?;
+        let hd_key_origin = HDKey::new(config.mnemonic.as_str())?;
         let signer = Signer::new(hd_key_origin, provider);
 
         Self::prepare_signer(&client, &signer, config.bitcoins)?;
@@ -42,7 +42,7 @@ impl Regtest {
         Ok((client, signer))
     }
 
-    fn prepare_signer<K: KeyProvider>(
+    fn prepare_signer<K: KeyOrigin>(
         client: &RegtestClient,
         signer: &Signer<K>,
         bitcoins: u64,

--- a/crates/sdk/src/provider/network.rs
+++ b/crates/sdk/src/provider/network.rs
@@ -3,6 +3,8 @@ use std::str::FromStr;
 use simplicityhl::simplicity::elements;
 use simplicityhl::simplicity::hashes::{Hash, sha256};
 
+use elements_miniscript::bitcoin::NetworkKind;
+
 use crate::constants::{LIQUID_DEFAULT_REGTEST_ASSET_STR, LIQUID_POLICY_ASSET_STR, LIQUID_TESTNET_POLICY_ASSET_STR};
 
 /// The default Bitcoin `AssetId` used on Liquid testnet.
@@ -98,6 +100,22 @@ impl SimplicityNetwork {
             Self::Liquid => &elements::AddressParams::LIQUID,
             Self::LiquidTestnet => &elements::AddressParams::LIQUID_TESTNET,
             Self::ElementsRegtest { .. } => &elements::AddressParams::ELEMENTS,
+        }
+    }
+}
+
+impl From<SimplicityNetwork> for NetworkKind {
+    fn from(value: SimplicityNetwork) -> Self {
+        (&value).into()
+    }
+}
+
+impl From<&SimplicityNetwork> for NetworkKind {
+    fn from(value: &SimplicityNetwork) -> Self {
+        if value.is_mainnet() {
+            NetworkKind::Main
+        } else {
+            NetworkKind::Test
         }
     }
 }

--- a/crates/sdk/src/provider/network.rs
+++ b/crates/sdk/src/provider/network.rs
@@ -3,8 +3,6 @@ use std::str::FromStr;
 use simplicityhl::simplicity::elements;
 use simplicityhl::simplicity::hashes::{Hash, sha256};
 
-use elements_miniscript::bitcoin::NetworkKind;
-
 use crate::constants::{LIQUID_DEFAULT_REGTEST_ASSET_STR, LIQUID_POLICY_ASSET_STR, LIQUID_TESTNET_POLICY_ASSET_STR};
 
 /// The default Bitcoin `AssetId` used on Liquid testnet.
@@ -100,22 +98,6 @@ impl SimplicityNetwork {
             Self::Liquid => &elements::AddressParams::LIQUID,
             Self::LiquidTestnet => &elements::AddressParams::LIQUID_TESTNET,
             Self::ElementsRegtest { .. } => &elements::AddressParams::ELEMENTS,
-        }
-    }
-}
-
-impl From<SimplicityNetwork> for NetworkKind {
-    fn from(value: SimplicityNetwork) -> Self {
-        (&value).into()
-    }
-}
-
-impl From<&SimplicityNetwork> for NetworkKind {
-    fn from(value: &SimplicityNetwork) -> Self {
-        if value.is_mainnet() {
-            NetworkKind::Main
-        } else {
-            NetworkKind::Test
         }
     }
 }

--- a/crates/sdk/src/signer/core.rs
+++ b/crates/sdk/src/signer/core.rs
@@ -71,7 +71,7 @@ pub trait SignerTrait {
 /// This trait abstracts the origin of the wallet's keys, allowing the `Signer` to remain
 /// agnostic to whether the keys are derived from a BIP39 mnemonic, a hardware wallet,
 /// or a single injected secret key.
-pub trait KeyProvider {
+pub trait KeyOrigin {
     /// Derives the X-Only public key specifically used for Schnorr and Taproot structures.
     #[must_use]
     fn get_schnorr_public_key(&self, secp: &Secp256k1<All>, network: &SimplicityNetwork) -> XOnlyPublicKey;
@@ -127,17 +127,17 @@ pub struct Signer<K> {
 
 /// A Hierarchical Deterministic (HD) key provider based on BIP39 and SLIP77.
 ///
-/// `HDKeyOrigin` derives its key material from a standard mnemonic seed phrase.
+/// `HDKey` derives its key material from a standard mnemonic seed phrase.
 /// It handles BIP32 derivation paths for standard transaction signing and uses
 /// SLIP77 to generate deterministic blinding keys for confidential transactions
 /// on the Elements/Liquid network.
-pub struct HDKeyOrigin {
+pub struct HDKey {
     xprv: Xpriv,
     master_blinding: MasterBlindingKey,
 }
 
-impl HDKeyOrigin {
-    /// Constructs a new `HDKeyOrigin` from a BIP39 mnemonic phrase.
+impl HDKey {
+    /// Constructs a new `HDKey` from a BIP39 mnemonic phrase.
     ///
     /// # Errors
     /// Returns a `SignerError::Mnemonic` if the provided phrase is invalid.
@@ -202,8 +202,7 @@ impl HDKeyOrigin {
     }
 }
 
-impl KeyProvider for HDKeyOrigin {
-    /// Derives the X-Only public key specifically used for Schnorr and Taproot structures.
+impl KeyOrigin for HDKey {
     fn get_schnorr_public_key(&self, secp: &Secp256k1<All>, network: &SimplicityNetwork) -> XOnlyPublicKey {
         let private_key = self.get_private_key(secp, network);
         let keypair = Keypair::from_secret_key(secp, &private_key.inner);
@@ -211,20 +210,14 @@ impl KeyProvider for HDKeyOrigin {
         keypair.x_only_public_key().0
     }
 
-    /// Resolves the standard format ECDSA public key.
     fn get_ecdsa_public_key(&self, secp: &Secp256k1<All>, network: &SimplicityNetwork) -> PublicKey {
         self.get_private_key(secp, network).public_key(secp)
     }
 
-    /// Resolves the corresponding blinding public key.
     fn get_blinding_public_key(&self, secp: &Secp256k1<All>, network: &SimplicityNetwork) -> PublicKey {
         self.get_blinding_private_key(secp, network).public_key(secp)
     }
 
-    /// Internally derives and exposes the wallet's signing active private key.
-    ///
-    /// # Panics
-    /// Panics if the master private key or derivation path cannot be derived.
     fn get_private_key(&self, secp: &Secp256k1<All>, network: &SimplicityNetwork) -> PrivateKey {
         let master_xprv = self.master_xpriv(secp).unwrap();
         let full_path = self.get_derivation_path(network).unwrap();
@@ -240,13 +233,6 @@ impl KeyProvider for HDKeyOrigin {
         PrivateKey::new(ext_derived.private_key, NetworkKind::Test)
     }
 
-    /// Generates the private key linked to confidential payload blinding.
-    ///
-    /// The generated `PrivateKey` is associated with the `Test` (non-Bitcoin-mainnet) network kind.
-    /// Retrieves the blinding private key derived from the master SLIP77 key and the script public key of the address.
-    ///
-    /// # Panics
-    /// Panics if the master SLIP77 key cannot be derived.
     fn get_blinding_private_key(&self, secp: &Secp256k1<All>, network: &SimplicityNetwork) -> PrivateKey {
         let blinding_key = self
             .master_blinding
@@ -255,10 +241,6 @@ impl KeyProvider for HDKeyOrigin {
         PrivateKey::new(blinding_key, NetworkKind::Test)
     }
 
-    /// Returns the confidential elements address matching the local wallet logic.
-    ///
-    /// # Panics
-    /// Panics if the SLIP77 descriptor cannot be generated or parsed, or if address derivation fails.
     fn get_confidential_address(&self, secp: &Secp256k1<All>, network: &SimplicityNetwork) -> Address {
         let mut descriptor = ConfidentialDescriptor::<DescriptorPublicKey>::from_str(
             &self.get_slip77_descriptor(secp, network).unwrap(),
@@ -276,10 +258,6 @@ impl KeyProvider for HDKeyOrigin {
             .unwrap()
     }
 
-    /// Returns the standard unblinded address matching the local wallet logic.
-    ///
-    /// # Panics
-    /// Panics if the WPKH descriptor cannot be generated or parsed, or if address derivation fails.
     fn get_address(&self, secp: &Secp256k1<All>, network: &SimplicityNetwork) -> Address {
         let descriptor = Descriptor::<DescriptorPublicKey>::from_str(&self.get_wpkh_descriptor(secp, network).unwrap())
             .map_err(|e| SignerError::WpkhDescriptor(e.to_string()))
@@ -295,16 +273,16 @@ impl KeyProvider for HDKeyOrigin {
 
 /// A simplified key provider powered by a single static secret key.
 ///
-/// Unlike `HDKeyOrigin` which derives paths hierarchically, `SingleKeyOrigin` uses
+/// Unlike `HDKey` which derives paths hierarchically, `SingleKey` uses
 /// exactly one `SecretKey` for all signing operations. It can optionally accept a
 /// `MasterBlindingKey` to support confidential transactions and blinded addresses.
-pub struct SingleKeyOrigin {
+pub struct SingleKey {
     secret_key: SecretKey,
     blinding_key: Option<MasterBlindingKey>,
 }
 
-impl SingleKeyOrigin {
-    /// Creates a new `SingleKeyOrigin`.
+impl SingleKey {
+    /// Creates a new `SingleKey`.
     ///
     /// # Arguments
     /// * `secret_key` - The base static secret key used for ECDSA and Schnorr signatures.
@@ -318,7 +296,7 @@ impl SingleKeyOrigin {
     }
 }
 
-impl KeyProvider for SingleKeyOrigin {
+impl KeyOrigin for SingleKey {
     fn get_schnorr_public_key(&self, secp: &Secp256k1<All>, _network: &SimplicityNetwork) -> XOnlyPublicKey {
         let keypair = Keypair::from_secret_key(secp, &self.secret_key);
         keypair.x_only_public_key().0
@@ -332,8 +310,8 @@ impl KeyProvider for SingleKeyOrigin {
         self.get_blinding_private_key(secp, network).public_key(secp)
     }
 
-    fn get_private_key(&self, _secp: &Secp256k1<All>, network: &SimplicityNetwork) -> PrivateKey {
-        PrivateKey::new(self.secret_key, network)
+    fn get_private_key(&self, _secp: &Secp256k1<All>, _network: &SimplicityNetwork) -> PrivateKey {
+        PrivateKey::new(self.secret_key, NetworkKind::Test)
     }
 
     fn get_blinding_private_key(&self, secp: &Secp256k1<All>, network: &SimplicityNetwork) -> PrivateKey {
@@ -344,7 +322,7 @@ impl KeyProvider for SingleKeyOrigin {
         let script_pubkey = self.get_address(secp, network).script_pubkey();
         let blinding_key = master_blinding.blinding_private_key(&script_pubkey);
 
-        PrivateKey::new(blinding_key, network)
+        PrivateKey::new(blinding_key, NetworkKind::Test)
     }
 
     fn get_confidential_address(&self, secp: &Secp256k1<All>, network: &SimplicityNetwork) -> Address {
@@ -374,7 +352,7 @@ impl<K> Signer<K> {
     }
 }
 
-impl<K: KeyProvider> Signer<K> {
+impl<K: KeyOrigin> Signer<K> {
     /// Creates a new `Signer` instance seeded from the provided key origin and paired with the specified provider.
     #[must_use]
     pub fn new(key_origin: K, provider: Box<dyn ProviderTrait>) -> Self {
@@ -810,11 +788,11 @@ mod tests {
 
     use super::*;
 
-    fn create_signer() -> Signer<HDKeyOrigin> {
+    fn create_signer() -> Signer<HDKey> {
         let url = "https://blockstream.info/liquidtestnet/api".to_string();
         let network = SimplicityNetwork::LiquidTestnet;
 
-        let hd_origin = HDKeyOrigin::new(random_mnemonic().as_str()).unwrap();
+        let hd_origin = HDKey::new(random_mnemonic().as_str()).unwrap();
 
         Signer::new(hd_origin, Box::new(EsploraProvider::new(url, network)))
     }

--- a/crates/sdk/src/signer/core.rs
+++ b/crates/sdk/src/signer/core.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use simplicityhl::Value;
 use simplicityhl::WitnessValues;
 use simplicityhl::elements::pset::PartiallySignedTransaction;
-use simplicityhl::elements::secp256k1_zkp::{All, Keypair, Message, Secp256k1, ecdsa, schnorr};
+use simplicityhl::elements::secp256k1_zkp::{All, Keypair, Message, Secp256k1, SecretKey, ecdsa, schnorr};
 use simplicityhl::elements::{Address, AssetId, OutPoint, Script, Transaction, Txid};
 use simplicityhl::simplicity::bitcoin::XOnlyPublicKey;
 use simplicityhl::simplicity::hashes::Hash;
@@ -66,53 +66,298 @@ pub trait SignerTrait {
     ) -> Result<(PublicKey, ecdsa::Signature), SignerError>;
 }
 
+/// A generalized interface for providing cryptographic keys and addresses.
+///
+/// This trait abstracts the origin of the wallet's keys, allowing the `Signer` to remain
+/// agnostic to whether the keys are derived from a BIP39 mnemonic, a hardware wallet,
+/// or a single injected secret key.
+pub trait KeyProvider {
+    /// Derives the X-Only public key specifically used for Schnorr and Taproot structures.
+    #[must_use]
+    fn get_schnorr_public_key(&self, secp: &Secp256k1<All>, network: &SimplicityNetwork) -> XOnlyPublicKey;
+
+    /// Resolves the standard format ECDSA public key.
+    #[must_use]
+    fn get_ecdsa_public_key(&self, secp: &Secp256k1<All>, network: &SimplicityNetwork) -> PublicKey;
+
+    /// Resolves the corresponding blinding public key.
+    #[must_use]
+    fn get_blinding_public_key(&self, secp: &Secp256k1<All>, network: &SimplicityNetwork) -> PublicKey;
+
+    /// Internally derives and exposes the wallet's signing active private key.
+    ///
+    /// # Panics
+    /// Panics if the master private key or derivation path cannot be derived.
+    #[must_use]
+    fn get_private_key(&self, secp: &Secp256k1<All>, network: &SimplicityNetwork) -> PrivateKey;
+
+    /// Generates the private key linked to confidential payload blinding.
+    ///
+    /// The generated `PrivateKey` is associated with the `Test` (non-Bitcoin-mainnet) network kind.
+    /// Retrieves the blinding private key derived from the master SLIP77 key and the script public key of the address.
+    ///
+    /// # Panics
+    /// Panics if the master SLIP77 key cannot be derived.
+    #[must_use]
+    fn get_blinding_private_key(&self, secp: &Secp256k1<All>, network: &SimplicityNetwork) -> PrivateKey;
+
+    /// Returns the confidential elements address matching the local wallet logic.
+    ///
+    /// # Panics
+    /// Panics if the SLIP77 descriptor cannot be generated or parsed, or if address derivation fails.
+    #[must_use]
+    fn get_confidential_address(&self, secp: &Secp256k1<All>, network: &SimplicityNetwork) -> Address;
+
+    /// Returns the standard unblinded address matching the local wallet logic.
+    ///
+    /// # Panics
+    /// Panics if the WPKH descriptor cannot be generated or parsed, or if address derivation fails.
+    #[must_use]
+    fn get_address(&self, secp: &Secp256k1<All>, network: &SimplicityNetwork) -> Address;
+}
+
 /// Core interface responsible for managing keys, interfacing with the blockchain provider,
 /// assembling descriptors, estimating fees, and finalizing/signing transactions.
-pub struct Signer {
-    mnemonic: Mnemonic,
-    xprv: Xpriv,
+pub struct Signer<K> {
+    key_origin: K,
     provider: Box<dyn ProviderTrait>,
     network: SimplicityNetwork,
     secp: Secp256k1<All>,
 }
 
-impl SignerTrait for Signer {
-    fn sign_program(
-        &self,
-        pst: &PartiallySignedTransaction,
-        program: &dyn ProgramTrait,
-        input_index: usize,
-        network: &SimplicityNetwork,
-    ) -> Result<schnorr::Signature, SignerError> {
-        let env = program.get_env(pst, input_index, network)?;
-        let msg = Message::from_digest(env.c_tx_env().sighash_all().to_byte_array());
+/// A Hierarchical Deterministic (HD) key provider based on BIP39 and SLIP77.
+///
+/// `HDKeyOrigin` derives its key material from a standard mnemonic seed phrase.
+/// It handles BIP32 derivation paths for standard transaction signing and uses
+/// SLIP77 to generate deterministic blinding keys for confidential transactions
+/// on the Elements/Liquid network.
+pub struct HDKeyOrigin {
+    xprv: Xpriv,
+    master_blinding: MasterBlindingKey,
+}
 
-        let private_key = self.get_private_key();
-        let keypair = Keypair::from_secret_key(&self.secp, &private_key.inner);
+impl HDKeyOrigin {
+    /// Constructs a new `HDKeyOrigin` from a BIP39 mnemonic phrase.
+    ///
+    /// # Errors
+    /// Returns a `SignerError::Mnemonic` if the provided phrase is invalid.
+    pub fn new(mnemonic: &str) -> Result<Self, SignerError> {
+        let mnemonic: Mnemonic = mnemonic
+            .parse()
+            .map_err(|e: bip39::Error| SignerError::Mnemonic(e.to_string()))?;
+        let seed = mnemonic.to_seed("");
+        let xprv = Xpriv::new_master(NetworkKind::Test, &seed)?;
 
-        Ok(self.secp.sign_schnorr(&msg, &keypair))
+        let master_blinding_key = MasterBlindingKey::from_seed(&seed[..]);
+
+        Ok(Self {
+            master_blinding: master_blinding_key,
+            xprv,
+        })
     }
 
-    fn sign_input(
-        &self,
-        pst: &PartiallySignedTransaction,
-        input_index: usize,
-    ) -> Result<(PublicKey, ecdsa::Signature), SignerError> {
-        let tx = pst.extract_tx()?;
+    fn derive_xpriv(&self, path: &DerivationPath, secp: &Secp256k1<All>) -> Result<Xpriv, SignerError> {
+        Ok(self.xprv.derive_priv(secp, path)?)
+    }
 
-        let mut sighash_cache = SighashCache::new(&tx);
-        let genesis_hash = elements_miniscript::elements::BlockHash::all_zeros();
+    fn master_xpriv(&self, secp: &Secp256k1<All>) -> Result<Xpriv, SignerError> {
+        self.derive_xpriv(&DerivationPath::master(), secp)
+    }
 
-        let message = pst
-            .sighash_msg(input_index, &mut sighash_cache, None, genesis_hash)?
-            .to_secp_msg();
+    fn derive_xpub(&self, path: &DerivationPath, secp: &Secp256k1<All>) -> Result<Xpub, SignerError> {
+        let derived = self.derive_xpriv(path, secp)?;
 
-        let private_key = self.get_private_key();
-        let public_key = private_key.public_key(&self.secp);
+        Ok(Xpub::from_priv(secp, &derived))
+    }
 
-        let signature = self.secp.sign_ecdsa_low_r(&message, &private_key.inner);
+    fn master_xpub(&self, secp: &Secp256k1<All>) -> Result<Xpub, SignerError> {
+        self.derive_xpub(&DerivationPath::master(), secp)
+    }
 
-        Ok((public_key, signature))
+    fn fingerprint(&self, secp: &Secp256k1<All>) -> Result<Fingerprint, SignerError> {
+        Ok(self.master_xpub(secp)?.fingerprint())
+    }
+
+    fn get_slip77_descriptor(&self, secp: &Secp256k1<All>, network: &SimplicityNetwork) -> Result<String, SignerError> {
+        let wpkh_descriptor = self.get_wpkh_descriptor(secp, network)?;
+        let blinding_key = self.master_blinding;
+
+        Ok(format!("ct(slip77({blinding_key}),{wpkh_descriptor})"))
+    }
+
+    fn get_wpkh_descriptor(&self, secp: &Secp256k1<All>, network: &SimplicityNetwork) -> Result<String, SignerError> {
+        let fingerprint = self.fingerprint(secp)?;
+        let path = self.get_derivation_path(network)?;
+        let xpub = self.derive_xpub(&path, secp)?;
+
+        Ok(format!("elwpkh([{fingerprint}/{path}]{xpub}/<0;1>/*)"))
+    }
+
+    #[allow(clippy::unused_self)]
+    fn get_derivation_path(&self, network: &SimplicityNetwork) -> Result<DerivationPath, SignerError> {
+        let coin_type = if network.is_mainnet() { 1776 } else { 1 };
+        let path = format!("84h/{coin_type}h/0h");
+
+        DerivationPath::from_str(&format!("m/{path}")).map_err(|e| SignerError::DerivationPath(e.to_string()))
+    }
+}
+
+impl KeyProvider for HDKeyOrigin {
+    /// Derives the X-Only public key specifically used for Schnorr and Taproot structures.
+    fn get_schnorr_public_key(&self, secp: &Secp256k1<All>, network: &SimplicityNetwork) -> XOnlyPublicKey {
+        let private_key = self.get_private_key(secp, network);
+        let keypair = Keypair::from_secret_key(secp, &private_key.inner);
+
+        keypair.x_only_public_key().0
+    }
+
+    /// Resolves the standard format ECDSA public key.
+    fn get_ecdsa_public_key(&self, secp: &Secp256k1<All>, network: &SimplicityNetwork) -> PublicKey {
+        self.get_private_key(secp, network).public_key(secp)
+    }
+
+    /// Resolves the corresponding blinding public key.
+    fn get_blinding_public_key(&self, secp: &Secp256k1<All>, network: &SimplicityNetwork) -> PublicKey {
+        self.get_blinding_private_key(secp, network).public_key(secp)
+    }
+
+    /// Internally derives and exposes the wallet's signing active private key.
+    ///
+    /// # Panics
+    /// Panics if the master private key or derivation path cannot be derived.
+    fn get_private_key(&self, secp: &Secp256k1<All>, network: &SimplicityNetwork) -> PrivateKey {
+        let master_xprv = self.master_xpriv(secp).unwrap();
+        let full_path = self.get_derivation_path(network).unwrap();
+
+        let derived = full_path.extend(
+            DerivationPath::from_str("0/1")
+                .map_err(|e| SignerError::DerivationPath(e.to_string()))
+                .unwrap(),
+        );
+
+        let ext_derived = master_xprv.derive_priv(secp, &derived).unwrap();
+
+        PrivateKey::new(ext_derived.private_key, NetworkKind::Test)
+    }
+
+    /// Generates the private key linked to confidential payload blinding.
+    ///
+    /// The generated `PrivateKey` is associated with the `Test` (non-Bitcoin-mainnet) network kind.
+    /// Retrieves the blinding private key derived from the master SLIP77 key and the script public key of the address.
+    ///
+    /// # Panics
+    /// Panics if the master SLIP77 key cannot be derived.
+    fn get_blinding_private_key(&self, secp: &Secp256k1<All>, network: &SimplicityNetwork) -> PrivateKey {
+        let blinding_key = self
+            .master_blinding
+            .blinding_private_key(&self.get_address(secp, network).script_pubkey());
+
+        PrivateKey::new(blinding_key, NetworkKind::Test)
+    }
+
+    /// Returns the confidential elements address matching the local wallet logic.
+    ///
+    /// # Panics
+    /// Panics if the SLIP77 descriptor cannot be generated or parsed, or if address derivation fails.
+    fn get_confidential_address(&self, secp: &Secp256k1<All>, network: &SimplicityNetwork) -> Address {
+        let mut descriptor = ConfidentialDescriptor::<DescriptorPublicKey>::from_str(
+            &self.get_slip77_descriptor(secp, network).unwrap(),
+        )
+        .map_err(|e| SignerError::Slip77Descriptor(e.to_string()))
+        .unwrap();
+
+        // confidential descriptor doesn't support multipath
+        descriptor.descriptor = descriptor.descriptor.into_single_descriptors().unwrap()[0].clone();
+
+        descriptor
+            .at_derivation_index(1)
+            .unwrap()
+            .address(secp, network.address_params())
+            .unwrap()
+    }
+
+    /// Returns the standard unblinded address matching the local wallet logic.
+    ///
+    /// # Panics
+    /// Panics if the WPKH descriptor cannot be generated or parsed, or if address derivation fails.
+    fn get_address(&self, secp: &Secp256k1<All>, network: &SimplicityNetwork) -> Address {
+        let descriptor = Descriptor::<DescriptorPublicKey>::from_str(&self.get_wpkh_descriptor(secp, network).unwrap())
+            .map_err(|e| SignerError::WpkhDescriptor(e.to_string()))
+            .unwrap();
+
+        descriptor.into_single_descriptors().unwrap()[0]
+            .at_derivation_index(1)
+            .unwrap()
+            .address(network.address_params())
+            .unwrap()
+    }
+}
+
+/// A simplified key provider powered by a single static secret key.
+///
+/// Unlike `HDKeyOrigin` which derives paths hierarchically, `SingleKeyOrigin` uses
+/// exactly one `SecretKey` for all signing operations. It can optionally accept a
+/// `MasterBlindingKey` to support confidential transactions and blinded addresses.
+pub struct SingleKeyOrigin {
+    secret_key: SecretKey,
+    blinding_key: Option<MasterBlindingKey>,
+}
+
+impl SingleKeyOrigin {
+    /// Creates a new `SingleKeyOrigin`.
+    ///
+    /// # Arguments
+    /// * `secret_key` - The base static secret key used for ECDSA and Schnorr signatures.
+    /// * `blinding_key` - An optional SLIP77 master blinding key.
+    #[must_use]
+    pub fn new(secret_key: SecretKey, blinding_key: Option<MasterBlindingKey>) -> Self {
+        Self {
+            secret_key,
+            blinding_key,
+        }
+    }
+}
+
+impl KeyProvider for SingleKeyOrigin {
+    fn get_schnorr_public_key(&self, secp: &Secp256k1<All>, _network: &SimplicityNetwork) -> XOnlyPublicKey {
+        let keypair = Keypair::from_secret_key(secp, &self.secret_key);
+        keypair.x_only_public_key().0
+    }
+
+    fn get_ecdsa_public_key(&self, secp: &Secp256k1<All>, network: &SimplicityNetwork) -> PublicKey {
+        self.get_private_key(secp, network).public_key(secp)
+    }
+
+    fn get_blinding_public_key(&self, secp: &Secp256k1<All>, network: &SimplicityNetwork) -> PublicKey {
+        self.get_blinding_private_key(secp, network).public_key(secp)
+    }
+
+    fn get_private_key(&self, _secp: &Secp256k1<All>, network: &SimplicityNetwork) -> PrivateKey {
+        PrivateKey::new(self.secret_key, network)
+    }
+
+    fn get_blinding_private_key(&self, secp: &Secp256k1<All>, network: &SimplicityNetwork) -> PrivateKey {
+        let master_blinding = self
+            .blinding_key
+            .expect("Blinding key is required for confidential operations");
+
+        let script_pubkey = self.get_address(secp, network).script_pubkey();
+        let blinding_key = master_blinding.blinding_private_key(&script_pubkey);
+
+        PrivateKey::new(blinding_key, network)
+    }
+
+    fn get_confidential_address(&self, secp: &Secp256k1<All>, network: &SimplicityNetwork) -> Address {
+        let ecdsa_pubkey = self.get_ecdsa_public_key(secp, network);
+        let blinding_pubkey = self.get_blinding_public_key(secp, network);
+
+        Address::p2wpkh(&ecdsa_pubkey, Some(blinding_pubkey.inner), network.address_params())
+    }
+
+    fn get_address(&self, secp: &Secp256k1<All>, network: &SimplicityNetwork) -> Address {
+        let ecdsa_pubkey = self.get_ecdsa_public_key(secp, network);
+
+        Address::p2wpkh(&ecdsa_pubkey, None, network.address_params())
     }
 }
 
@@ -121,30 +366,37 @@ enum Estimate {
     Failure(u64),
 }
 
-impl Signer {
-    /// Creates a new `Signer` instance seeded from the provided mnemonic and paired with the specified provider.
-    ///
-    /// # Panics
-    /// Panics if the mnemonic fails to parse, or if deriving the master private key fails.
+impl<K> Signer<K> {
+    /// Returns a reference to the active configured network provider.
     #[must_use]
-    pub fn new(mnemonic: &str, provider: Box<dyn ProviderTrait>) -> Self {
-        let secp = Secp256k1::new();
-        let mnemonic: Mnemonic = mnemonic
-            .parse()
-            .map_err(|e: bip39::Error| SignerError::Mnemonic(e.to_string()))
-            .unwrap();
-        let seed = mnemonic.to_seed("");
-        let xprv = Xpriv::new_master(NetworkKind::Test, &seed).unwrap();
+    pub fn get_provider(&self) -> &dyn ProviderTrait {
+        self.provider.as_ref()
+    }
+}
 
+impl<K: KeyProvider> Signer<K> {
+    /// Creates a new `Signer` instance seeded from the provided key origin and paired with the specified provider.
+    #[must_use]
+    pub fn new(key_origin: K, provider: Box<dyn ProviderTrait>) -> Self {
+        let secp = Secp256k1::new();
         let network = *provider.get_network();
 
         Self {
-            mnemonic,
-            xprv,
+            key_origin,
             provider,
             network,
             secp,
         }
+    }
+
+    /// Evaluates, funds, and broadcasts an already assembled `FinalTransaction`.
+    ///
+    /// # Errors
+    /// Returns a `SignerError` if finalizing the payload fails or if the network rejects the broadcast.
+    pub fn broadcast(&self, tx: &FinalTransaction) -> Result<TxReceipt<'_>, SignerError> {
+        let (tx, _fee) = self.finalize(tx)?;
+
+        Ok(self.provider.broadcast_transaction(&tx)?)
     }
 
     /// Composes, funds, and broadcasts a standard network transaction sending the specified value of the primary policy asset.
@@ -162,14 +414,41 @@ impl Signer {
         Ok(self.provider.broadcast_transaction(&tx)?)
     }
 
-    /// Evaluates, funds, and broadcasts an already assembled `FinalTransaction`.
-    ///
-    /// # Errors
-    /// Returns a `SignerError` if finalizing the payload fails or if the network rejects the broadcast.
-    pub fn broadcast(&self, tx: &FinalTransaction) -> Result<TxReceipt<'_>, SignerError> {
-        let (tx, _fee) = self.finalize(tx)?;
+    /// Proxies to the underlying key provider to get the Schnorr public key.
+    pub fn get_schnorr_public_key(&self) -> XOnlyPublicKey {
+        self.key_origin.get_schnorr_public_key(&self.secp, &self.network)
+    }
 
-        Ok(self.provider.broadcast_transaction(&tx)?)
+    /// Proxies to the underlying key provider to get the ECDSA public key.
+    pub fn get_ecdsa_public_key(&self) -> PublicKey {
+        self.key_origin.get_ecdsa_public_key(&self.secp, &self.network)
+    }
+
+    /// Proxies to the underlying key provider to get the blinding public key.
+    pub fn get_blinding_public_key(&self) -> PublicKey {
+        self.key_origin.get_blinding_public_key(&self.secp, &self.network)
+    }
+
+    /// Proxies to the underlying key provider to get the active private key.
+    pub fn get_private_key(&self) -> PrivateKey {
+        self.key_origin.get_private_key(&self.secp, &self.network)
+    }
+
+    /// Proxies to the underlying key provider to get the blinding private key.
+    pub fn get_blinding_private_key(&self) -> PrivateKey {
+        self.key_origin.get_blinding_private_key(&self.secp, &self.network)
+    }
+
+    /// Proxies to the underlying key provider to get the confidential address.
+    #[must_use]
+    pub fn get_confidential_address(&self) -> Address {
+        self.key_origin.get_confidential_address(&self.secp, &self.network)
+    }
+
+    /// Proxies to the underlying key provider to get the standard unblinded address.
+    #[must_use]
+    pub fn get_address(&self) -> Address {
+        self.key_origin.get_address(&self.secp, &self.network)
     }
 
     /// Evaluates the input components of a `FinalTransaction`, iteratively selecting available wallet UTXOs to cover outputs and estimated fees.
@@ -257,50 +536,6 @@ impl Signer {
         }
     }
 
-    /// Returns a reference to the active configured network provider.
-    #[must_use]
-    pub fn get_provider(&self) -> &dyn ProviderTrait {
-        self.provider.as_ref()
-    }
-
-    /// Returns the confidential elements address matching the local wallet logic.
-    ///
-    /// # Panics
-    /// Panics if the SLIP77 descriptor cannot be generated or parsed, or if address derivation fails.
-    #[must_use]
-    pub fn get_confidential_address(&self) -> Address {
-        let mut descriptor =
-            ConfidentialDescriptor::<DescriptorPublicKey>::from_str(&self.get_slip77_descriptor().unwrap())
-                .map_err(|e| SignerError::Slip77Descriptor(e.to_string()))
-                .unwrap();
-
-        // confidential descriptor doesn't support multipath
-        descriptor.descriptor = descriptor.descriptor.into_single_descriptors().unwrap()[0].clone();
-
-        descriptor
-            .at_derivation_index(1)
-            .unwrap()
-            .address(&self.secp, self.network.address_params())
-            .unwrap()
-    }
-
-    /// Returns the standard unblinded address matching the local wallet logic.
-    ///
-    /// # Panics
-    /// Panics if the WPKH descriptor cannot be generated or parsed, or if address derivation fails.
-    #[must_use]
-    pub fn get_address(&self) -> Address {
-        let descriptor = Descriptor::<DescriptorPublicKey>::from_str(&self.get_wpkh_descriptor().unwrap())
-            .map_err(|e| SignerError::WpkhDescriptor(e.to_string()))
-            .unwrap();
-
-        descriptor.into_single_descriptors().unwrap()[0]
-            .at_derivation_index(1)
-            .unwrap()
-            .address(self.network.address_params())
-            .unwrap()
-    }
-
     /// Iterates against the network provider to select and unblind all known UTXOs.
     ///
     /// # Errors
@@ -337,7 +572,9 @@ impl Signer {
         confidential_filter: &dyn Fn(&UTXO) -> bool,
     ) -> Result<Vec<UTXO>, SignerError> {
         // fetch explicit and confidential utxos
-        let mut all_utxos = self.provider.fetch_address_utxos(&self.get_confidential_address())?;
+        let mut all_utxos = self
+            .provider
+            .fetch_address_utxos(&self.key_origin.get_confidential_address(&self.secp, &self.network))?;
 
         // filter out only confidential utxos and unblind them
         let mut confidential_utxos = self.unblind(
@@ -357,64 +594,6 @@ impl Signer {
         all_utxos.extend(confidential_utxos);
 
         Ok(all_utxos)
-    }
-
-    /// Derives the X-Only public key specifically used for Schnorr and Taproot structures.
-    #[must_use]
-    pub fn get_schnorr_public_key(&self) -> XOnlyPublicKey {
-        let private_key = self.get_private_key();
-        let keypair = Keypair::from_secret_key(&self.secp, &private_key.inner);
-
-        keypair.x_only_public_key().0
-    }
-
-    /// Resolves the standard format ECDSA public key.
-    #[must_use]
-    pub fn get_ecdsa_public_key(&self) -> PublicKey {
-        self.get_private_key().public_key(&self.secp)
-    }
-
-    /// Resolves the corresponding blinding public key.
-    #[must_use]
-    pub fn get_blinding_public_key(&self) -> PublicKey {
-        self.get_blinding_private_key().public_key(&self.secp)
-    }
-
-    /// Internally derives and exposes the wallet's signing active private key.
-    ///
-    /// # Panics
-    /// Panics if the master private key or derivation path cannot be derived.
-    #[must_use]
-    pub fn get_private_key(&self) -> PrivateKey {
-        let master_xprv = self.master_xpriv().unwrap();
-        let full_path = self.get_derivation_path().unwrap();
-
-        let derived = full_path.extend(
-            DerivationPath::from_str("0/1")
-                .map_err(|e| SignerError::DerivationPath(e.to_string()))
-                .unwrap(),
-        );
-
-        let ext_derived = master_xprv.derive_priv(&self.secp, &derived).unwrap();
-
-        PrivateKey::new(ext_derived.private_key, NetworkKind::Test)
-    }
-
-    /// Generates the private key linked to confidential payload blinding.
-    ///
-    /// The generated `PrivateKey` is associated with the `Test` (non-Bitcoin-mainnet) network kind.
-    /// Retrieves the blinding private key derived from the master SLIP77 key and the script public key of the address.
-    ///
-    /// # Panics
-    /// Panics if the master SLIP77 key cannot be derived.
-    #[must_use]
-    pub fn get_blinding_private_key(&self) -> PrivateKey {
-        let blinding_key = self
-            .master_slip77()
-            .unwrap()
-            .blinding_private_key(&self.get_address().script_pubkey());
-
-        PrivateKey::new(blinding_key, NetworkKind::Test)
     }
 
     fn unblind(&self, utxos: Vec<UTXO>) -> Result<Vec<UTXO>, SignerError> {
@@ -539,6 +718,44 @@ impl Signer {
         Ok(pst.extract_tx()?)
     }
 
+    fn sign_program(
+        &self,
+        pst: &PartiallySignedTransaction,
+        program: &dyn ProgramTrait,
+        input_index: usize,
+        network: &SimplicityNetwork,
+    ) -> Result<schnorr::Signature, SignerError> {
+        let env = program.get_env(pst, input_index, network)?;
+        let msg = Message::from_digest(env.c_tx_env().sighash_all().to_byte_array());
+
+        let private_key = self.get_private_key();
+        let keypair = Keypair::from_secret_key(&self.secp, &private_key.inner);
+
+        Ok(self.secp.sign_schnorr(&msg, &keypair))
+    }
+
+    fn sign_input(
+        &self,
+        pst: &PartiallySignedTransaction,
+        input_index: usize,
+    ) -> Result<(PublicKey, ecdsa::Signature), SignerError> {
+        let tx = pst.extract_tx()?;
+
+        let mut sighash_cache = SighashCache::new(&tx);
+        let genesis_hash = elements_miniscript::elements::BlockHash::all_zeros();
+
+        let message = pst
+            .sighash_msg(input_index, &mut sighash_cache, None, genesis_hash)?
+            .to_secp_msg();
+
+        let private_key = self.get_private_key();
+        let public_key = private_key.public_key(&self.secp);
+
+        let signature = self.secp.sign_ecdsa_low_r(&message, &private_key.inner);
+
+        Ok((public_key, signature))
+    }
+
     fn get_signed_program_witness(
         &self,
         pst: &PartiallySignedTransaction,
@@ -584,57 +801,6 @@ impl Signer {
 
         Ok(WitnessValues::from(hm))
     }
-
-    #[allow(clippy::unnecessary_wraps)]
-    fn master_slip77(&self) -> Result<MasterBlindingKey, SignerError> {
-        let seed = self.mnemonic.to_seed("");
-
-        Ok(MasterBlindingKey::from_seed(&seed[..]))
-    }
-
-    fn derive_xpriv(&self, path: &DerivationPath) -> Result<Xpriv, SignerError> {
-        Ok(self.xprv.derive_priv(&self.secp, &path)?)
-    }
-
-    fn master_xpriv(&self) -> Result<Xpriv, SignerError> {
-        self.derive_xpriv(&DerivationPath::master())
-    }
-
-    fn derive_xpub(&self, path: &DerivationPath) -> Result<Xpub, SignerError> {
-        let derived = self.derive_xpriv(path)?;
-
-        Ok(Xpub::from_priv(&self.secp, &derived))
-    }
-
-    fn master_xpub(&self) -> Result<Xpub, SignerError> {
-        self.derive_xpub(&DerivationPath::master())
-    }
-
-    fn fingerprint(&self) -> Result<Fingerprint, SignerError> {
-        Ok(self.master_xpub()?.fingerprint())
-    }
-
-    fn get_slip77_descriptor(&self) -> Result<String, SignerError> {
-        let wpkh_descriptor = self.get_wpkh_descriptor()?;
-        let blinding_key = self.master_slip77()?;
-
-        Ok(format!("ct(slip77({blinding_key}),{wpkh_descriptor})"))
-    }
-
-    fn get_wpkh_descriptor(&self) -> Result<String, SignerError> {
-        let fingerprint = self.fingerprint()?;
-        let path = self.get_derivation_path()?;
-        let xpub = self.derive_xpub(&path)?;
-
-        Ok(format!("elwpkh([{fingerprint}/{path}]{xpub}/<0;1>/*)"))
-    }
-
-    fn get_derivation_path(&self) -> Result<DerivationPath, SignerError> {
-        let coin_type = if self.network.is_mainnet() { 1776 } else { 1 };
-        let path = format!("84h/{coin_type}h/0h");
-
-        DerivationPath::from_str(&format!("m/{path}")).map_err(|e| SignerError::DerivationPath(e.to_string()))
-    }
 }
 
 #[cfg(test)]
@@ -644,11 +810,13 @@ mod tests {
 
     use super::*;
 
-    fn create_signer() -> Signer {
+    fn create_signer() -> Signer<HDKeyOrigin> {
         let url = "https://blockstream.info/liquidtestnet/api".to_string();
         let network = SimplicityNetwork::LiquidTestnet;
 
-        Signer::new(random_mnemonic().as_str(), Box::new(EsploraProvider::new(url, network)))
+        let hd_origin = HDKeyOrigin::new(random_mnemonic().as_str()).unwrap();
+
+        Signer::new(hd_origin, Box::new(EsploraProvider::new(url, network)))
     }
 
     #[test]

--- a/crates/sdk/src/signer/core.rs
+++ b/crates/sdk/src/signer/core.rs
@@ -1,31 +1,23 @@
 use std::collections::{HashMap, HashSet};
-use std::str::FromStr;
 use std::sync::Arc;
 
 use simplicityhl::Value;
 use simplicityhl::WitnessValues;
 use simplicityhl::elements::pset::PartiallySignedTransaction;
-use simplicityhl::elements::secp256k1_zkp::{All, Keypair, Message, Secp256k1, SecretKey, ecdsa, schnorr};
+use simplicityhl::elements::secp256k1_zkp::{All, Keypair, Message, Secp256k1, ecdsa, schnorr};
 use simplicityhl::elements::{Address, AssetId, OutPoint, Script, Transaction, Txid};
 use simplicityhl::simplicity::bitcoin::XOnlyPublicKey;
 use simplicityhl::simplicity::hashes::Hash;
 use simplicityhl::str::WitnessName;
 use simplicityhl::value::ValueConstructible;
 
-use bip39::Mnemonic;
 use bip39::rand::thread_rng;
 
 use elements_miniscript::{
-    ConfidentialDescriptor, Descriptor, DescriptorPublicKey,
-    bitcoin::{NetworkKind, PrivateKey, PublicKey, bip32::DerivationPath},
-    elements::{
-        EcdsaSighashType,
-        bitcoin::bip32::{Fingerprint, Xpriv, Xpub},
-        sighash::SighashCache,
-    },
+    bitcoin::{PrivateKey, PublicKey},
+    elements::{EcdsaSighashType, sighash::SighashCache},
     elementssig_to_rawsig,
     psbt::PsbtExt,
-    slip77::MasterBlindingKey,
 };
 
 use crate::constants::MIN_FEE;
@@ -33,6 +25,7 @@ use crate::program::ProgramTrait;
 use crate::program::logger::ProgramLogger;
 use crate::provider::ProviderTrait;
 use crate::provider::SimplicityNetwork;
+use crate::signer::KeyOrigin;
 use crate::signer::wtns_injector::WtnsInjector;
 use crate::transaction::{FinalTransaction, PartialInput, PartialOutput, RequiredSignature, TxReceipt, UTXO};
 
@@ -66,56 +59,6 @@ pub trait SignerTrait {
     ) -> Result<(PublicKey, ecdsa::Signature), SignerError>;
 }
 
-/// A generalized interface for providing cryptographic keys and addresses.
-///
-/// This trait abstracts the origin of the wallet's keys, allowing the `Signer` to remain
-/// agnostic to whether the keys are derived from a BIP39 mnemonic, a hardware wallet,
-/// or a single injected secret key.
-pub trait KeyOrigin {
-    /// Derives the X-Only public key specifically used for Schnorr and Taproot structures.
-    #[must_use]
-    fn get_schnorr_public_key(&self, secp: &Secp256k1<All>, network: &SimplicityNetwork) -> XOnlyPublicKey;
-
-    /// Resolves the standard format ECDSA public key.
-    #[must_use]
-    fn get_ecdsa_public_key(&self, secp: &Secp256k1<All>, network: &SimplicityNetwork) -> PublicKey;
-
-    /// Resolves the corresponding blinding public key.
-    #[must_use]
-    fn get_blinding_public_key(&self, secp: &Secp256k1<All>, network: &SimplicityNetwork) -> PublicKey;
-
-    /// Internally derives and exposes the wallet's signing active private key.
-    ///
-    /// # Panics
-    /// Panics if the master private key or derivation path cannot be derived.
-    #[must_use]
-    fn get_private_key(&self, secp: &Secp256k1<All>, network: &SimplicityNetwork) -> PrivateKey;
-
-    /// Generates the private key linked to confidential payload blinding.
-    ///
-    /// The generated `PrivateKey` is associated with the `Test` (non-Bitcoin-mainnet) network kind.
-    /// Retrieves the blinding private key derived from the master SLIP77 key and the script public key of the address.
-    ///
-    /// # Panics
-    /// Panics if the master SLIP77 key cannot be derived.
-    #[must_use]
-    fn get_blinding_private_key(&self, secp: &Secp256k1<All>, network: &SimplicityNetwork) -> PrivateKey;
-
-    /// Returns the confidential elements address matching the local wallet logic.
-    ///
-    /// # Panics
-    /// Panics if the SLIP77 descriptor cannot be generated or parsed, or if address derivation fails.
-    #[must_use]
-    fn get_confidential_address(&self, secp: &Secp256k1<All>, network: &SimplicityNetwork) -> Address;
-
-    /// Returns the standard unblinded address matching the local wallet logic.
-    ///
-    /// # Panics
-    /// Panics if the WPKH descriptor cannot be generated or parsed, or if address derivation fails.
-    #[must_use]
-    fn get_address(&self, secp: &Secp256k1<All>, network: &SimplicityNetwork) -> Address;
-}
-
 /// Core interface responsible for managing keys, interfacing with the blockchain provider,
 /// assembling descriptors, estimating fees, and finalizing/signing transactions.
 pub struct Signer<K> {
@@ -123,220 +66,6 @@ pub struct Signer<K> {
     provider: Box<dyn ProviderTrait>,
     network: SimplicityNetwork,
     secp: Secp256k1<All>,
-}
-
-/// A Hierarchical Deterministic (HD) key provider based on BIP39 and SLIP77.
-///
-/// `HDKey` derives its key material from a standard mnemonic seed phrase.
-/// It handles BIP32 derivation paths for standard transaction signing and uses
-/// SLIP77 to generate deterministic blinding keys for confidential transactions
-/// on the Elements/Liquid network.
-pub struct HDKey {
-    xprv: Xpriv,
-    master_blinding: MasterBlindingKey,
-}
-
-impl HDKey {
-    /// Constructs a new `HDKey` from a BIP39 mnemonic phrase.
-    ///
-    /// # Errors
-    /// Returns a `SignerError::Mnemonic` if the provided phrase is invalid.
-    pub fn new(mnemonic: &str) -> Result<Self, SignerError> {
-        let mnemonic: Mnemonic = mnemonic
-            .parse()
-            .map_err(|e: bip39::Error| SignerError::Mnemonic(e.to_string()))?;
-        let seed = mnemonic.to_seed("");
-        let xprv = Xpriv::new_master(NetworkKind::Test, &seed)?;
-
-        let master_blinding_key = MasterBlindingKey::from_seed(&seed[..]);
-
-        Ok(Self {
-            master_blinding: master_blinding_key,
-            xprv,
-        })
-    }
-
-    fn derive_xpriv(&self, path: &DerivationPath, secp: &Secp256k1<All>) -> Result<Xpriv, SignerError> {
-        Ok(self.xprv.derive_priv(secp, path)?)
-    }
-
-    fn master_xpriv(&self, secp: &Secp256k1<All>) -> Result<Xpriv, SignerError> {
-        self.derive_xpriv(&DerivationPath::master(), secp)
-    }
-
-    fn derive_xpub(&self, path: &DerivationPath, secp: &Secp256k1<All>) -> Result<Xpub, SignerError> {
-        let derived = self.derive_xpriv(path, secp)?;
-
-        Ok(Xpub::from_priv(secp, &derived))
-    }
-
-    fn master_xpub(&self, secp: &Secp256k1<All>) -> Result<Xpub, SignerError> {
-        self.derive_xpub(&DerivationPath::master(), secp)
-    }
-
-    fn fingerprint(&self, secp: &Secp256k1<All>) -> Result<Fingerprint, SignerError> {
-        Ok(self.master_xpub(secp)?.fingerprint())
-    }
-
-    fn get_slip77_descriptor(&self, secp: &Secp256k1<All>, network: &SimplicityNetwork) -> Result<String, SignerError> {
-        let wpkh_descriptor = self.get_wpkh_descriptor(secp, network)?;
-        let blinding_key = self.master_blinding;
-
-        Ok(format!("ct(slip77({blinding_key}),{wpkh_descriptor})"))
-    }
-
-    fn get_wpkh_descriptor(&self, secp: &Secp256k1<All>, network: &SimplicityNetwork) -> Result<String, SignerError> {
-        let fingerprint = self.fingerprint(secp)?;
-        let path = self.get_derivation_path(network)?;
-        let xpub = self.derive_xpub(&path, secp)?;
-
-        Ok(format!("elwpkh([{fingerprint}/{path}]{xpub}/<0;1>/*)"))
-    }
-
-    #[allow(clippy::unused_self)]
-    fn get_derivation_path(&self, network: &SimplicityNetwork) -> Result<DerivationPath, SignerError> {
-        let coin_type = if network.is_mainnet() { 1776 } else { 1 };
-        let path = format!("84h/{coin_type}h/0h");
-
-        DerivationPath::from_str(&format!("m/{path}")).map_err(|e| SignerError::DerivationPath(e.to_string()))
-    }
-}
-
-impl KeyOrigin for HDKey {
-    fn get_schnorr_public_key(&self, secp: &Secp256k1<All>, network: &SimplicityNetwork) -> XOnlyPublicKey {
-        let private_key = self.get_private_key(secp, network);
-        let keypair = Keypair::from_secret_key(secp, &private_key.inner);
-
-        keypair.x_only_public_key().0
-    }
-
-    fn get_ecdsa_public_key(&self, secp: &Secp256k1<All>, network: &SimplicityNetwork) -> PublicKey {
-        self.get_private_key(secp, network).public_key(secp)
-    }
-
-    fn get_blinding_public_key(&self, secp: &Secp256k1<All>, network: &SimplicityNetwork) -> PublicKey {
-        self.get_blinding_private_key(secp, network).public_key(secp)
-    }
-
-    fn get_private_key(&self, secp: &Secp256k1<All>, network: &SimplicityNetwork) -> PrivateKey {
-        let master_xprv = self.master_xpriv(secp).unwrap();
-        let full_path = self.get_derivation_path(network).unwrap();
-
-        let derived = full_path.extend(
-            DerivationPath::from_str("0/1")
-                .map_err(|e| SignerError::DerivationPath(e.to_string()))
-                .unwrap(),
-        );
-
-        let ext_derived = master_xprv.derive_priv(secp, &derived).unwrap();
-
-        PrivateKey::new(ext_derived.private_key, NetworkKind::Test)
-    }
-
-    fn get_blinding_private_key(&self, secp: &Secp256k1<All>, network: &SimplicityNetwork) -> PrivateKey {
-        let blinding_key = self
-            .master_blinding
-            .blinding_private_key(&self.get_address(secp, network).script_pubkey());
-
-        PrivateKey::new(blinding_key, NetworkKind::Test)
-    }
-
-    fn get_confidential_address(&self, secp: &Secp256k1<All>, network: &SimplicityNetwork) -> Address {
-        let mut descriptor = ConfidentialDescriptor::<DescriptorPublicKey>::from_str(
-            &self.get_slip77_descriptor(secp, network).unwrap(),
-        )
-        .map_err(|e| SignerError::Slip77Descriptor(e.to_string()))
-        .unwrap();
-
-        // confidential descriptor doesn't support multipath
-        descriptor.descriptor = descriptor.descriptor.into_single_descriptors().unwrap()[0].clone();
-
-        descriptor
-            .at_derivation_index(1)
-            .unwrap()
-            .address(secp, network.address_params())
-            .unwrap()
-    }
-
-    fn get_address(&self, secp: &Secp256k1<All>, network: &SimplicityNetwork) -> Address {
-        let descriptor = Descriptor::<DescriptorPublicKey>::from_str(&self.get_wpkh_descriptor(secp, network).unwrap())
-            .map_err(|e| SignerError::WpkhDescriptor(e.to_string()))
-            .unwrap();
-
-        descriptor.into_single_descriptors().unwrap()[0]
-            .at_derivation_index(1)
-            .unwrap()
-            .address(network.address_params())
-            .unwrap()
-    }
-}
-
-/// A simplified key provider powered by a single static secret key.
-///
-/// Unlike `HDKey` which derives paths hierarchically, `SingleKey` uses
-/// exactly one `SecretKey` for all signing operations. It can optionally accept a
-/// `MasterBlindingKey` to support confidential transactions and blinded addresses.
-pub struct SingleKey {
-    secret_key: SecretKey,
-    blinding_key: Option<MasterBlindingKey>,
-}
-
-impl SingleKey {
-    /// Creates a new `SingleKey`.
-    ///
-    /// # Arguments
-    /// * `secret_key` - The base static secret key used for ECDSA and Schnorr signatures.
-    /// * `blinding_key` - An optional SLIP77 master blinding key.
-    #[must_use]
-    pub fn new(secret_key: SecretKey, blinding_key: Option<MasterBlindingKey>) -> Self {
-        Self {
-            secret_key,
-            blinding_key,
-        }
-    }
-}
-
-impl KeyOrigin for SingleKey {
-    fn get_schnorr_public_key(&self, secp: &Secp256k1<All>, _network: &SimplicityNetwork) -> XOnlyPublicKey {
-        let keypair = Keypair::from_secret_key(secp, &self.secret_key);
-        keypair.x_only_public_key().0
-    }
-
-    fn get_ecdsa_public_key(&self, secp: &Secp256k1<All>, network: &SimplicityNetwork) -> PublicKey {
-        self.get_private_key(secp, network).public_key(secp)
-    }
-
-    fn get_blinding_public_key(&self, secp: &Secp256k1<All>, network: &SimplicityNetwork) -> PublicKey {
-        self.get_blinding_private_key(secp, network).public_key(secp)
-    }
-
-    fn get_private_key(&self, _secp: &Secp256k1<All>, _network: &SimplicityNetwork) -> PrivateKey {
-        PrivateKey::new(self.secret_key, NetworkKind::Test)
-    }
-
-    fn get_blinding_private_key(&self, secp: &Secp256k1<All>, network: &SimplicityNetwork) -> PrivateKey {
-        let master_blinding = self
-            .blinding_key
-            .expect("Blinding key is required for confidential operations");
-
-        let script_pubkey = self.get_address(secp, network).script_pubkey();
-        let blinding_key = master_blinding.blinding_private_key(&script_pubkey);
-
-        PrivateKey::new(blinding_key, NetworkKind::Test)
-    }
-
-    fn get_confidential_address(&self, secp: &Secp256k1<All>, network: &SimplicityNetwork) -> Address {
-        let ecdsa_pubkey = self.get_ecdsa_public_key(secp, network);
-        let blinding_pubkey = self.get_blinding_public_key(secp, network);
-
-        Address::p2wpkh(&ecdsa_pubkey, Some(blinding_pubkey.inner), network.address_params())
-    }
-
-    fn get_address(&self, secp: &Secp256k1<All>, network: &SimplicityNetwork) -> Address {
-        let ecdsa_pubkey = self.get_ecdsa_public_key(secp, network);
-
-        Address::p2wpkh(&ecdsa_pubkey, None, network.address_params())
-    }
 }
 
 enum Estimate {
@@ -784,6 +513,7 @@ impl<K: KeyOrigin> Signer<K> {
 #[cfg(test)]
 mod tests {
     use crate::provider::EsploraProvider;
+    use crate::signer::HDKey;
     use crate::utils::random_mnemonic;
 
     use super::*;
@@ -792,9 +522,10 @@ mod tests {
         let url = "https://blockstream.info/liquidtestnet/api".to_string();
         let network = SimplicityNetwork::LiquidTestnet;
 
-        let hd_origin = HDKey::new(random_mnemonic().as_str()).unwrap();
-
-        Signer::new(hd_origin, Box::new(EsploraProvider::new(url, network)))
+        Signer::new(
+            HDKey::new(random_mnemonic().as_str()).unwrap(),
+            Box::new(EsploraProvider::new(url, network)),
+        )
     }
 
     #[test]

--- a/crates/sdk/src/signer/core.rs
+++ b/crates/sdk/src/signer/core.rs
@@ -29,7 +29,7 @@ use crate::signer::KeyOrigin;
 use crate::signer::wtns_injector::WtnsInjector;
 use crate::transaction::{FinalTransaction, PartialInput, PartialOutput, RequiredSignature, TxReceipt, UTXO};
 
-use super::error::SignerError;
+use super::error::{KeyOriginError, SignerError};
 
 /// A placeholder dummy fee amount used during transaction estimation.
 pub const PLACEHOLDER_FEE: u64 = 1;
@@ -66,6 +66,46 @@ pub struct Signer<K> {
     provider: Box<dyn ProviderTrait>,
     network: SimplicityNetwork,
     secp: Secp256k1<All>,
+}
+
+impl<K: KeyOrigin> SignerTrait for Signer<K> {
+    fn sign_program(
+        &self,
+        pst: &PartiallySignedTransaction,
+        program: &dyn ProgramTrait,
+        input_index: usize,
+        network: &SimplicityNetwork,
+    ) -> Result<schnorr::Signature, SignerError> {
+        let env = program.get_env(pst, input_index, network)?;
+        let msg = Message::from_digest(env.c_tx_env().sighash_all().to_byte_array());
+
+        let private_key = self.get_private_key();
+        let keypair = Keypair::from_secret_key(&self.secp, &private_key.inner);
+
+        Ok(self.secp.sign_schnorr(&msg, &keypair))
+    }
+
+    fn sign_input(
+        &self,
+        pst: &PartiallySignedTransaction,
+        input_index: usize,
+    ) -> Result<(PublicKey, ecdsa::Signature), SignerError> {
+        let tx = pst.extract_tx()?;
+
+        let mut sighash_cache = SighashCache::new(&tx);
+        let genesis_hash = elements_miniscript::elements::BlockHash::all_zeros();
+
+        let message = pst
+            .sighash_msg(input_index, &mut sighash_cache, None, genesis_hash)?
+            .to_secp_msg();
+
+        let private_key = self.get_private_key();
+        let public_key = private_key.public_key(&self.secp);
+
+        let signature = self.secp.sign_ecdsa_low_r(&message, &private_key.inner);
+
+        Ok((public_key, signature))
+    }
 }
 
 enum Estimate {
@@ -132,8 +172,14 @@ impl<K: KeyOrigin> Signer<K> {
     }
 
     /// Proxies to the underlying key provider to get the blinding public key.
-    pub fn get_blinding_public_key(&self) -> PublicKey {
-        self.key_origin.get_blinding_public_key(&self.secp, &self.network)
+    ///
+    /// # Errors
+    /// Returns a `SignerError` if the unblinding key is missing or fails to derive.
+    pub fn get_blinding_public_key(&self) -> Result<PublicKey, SignerError> {
+        Ok(self
+            .key_origin
+            .get_blinding_public_key(&self.secp, &self.network)
+            .ok_or(KeyOriginError::RequiredUnblindingKey)?)
     }
 
     /// Proxies to the underlying key provider to get the active private key.
@@ -142,14 +188,25 @@ impl<K: KeyOrigin> Signer<K> {
     }
 
     /// Proxies to the underlying key provider to get the blinding private key.
-    pub fn get_blinding_private_key(&self) -> PrivateKey {
-        self.key_origin.get_blinding_private_key(&self.secp, &self.network)
+    ///
+    /// # Errors
+    /// Returns a `SignerError` if the unblinding key is missing or fails to derive.
+    pub fn get_blinding_private_key(&self) -> Result<PrivateKey, SignerError> {
+        Ok(self
+            .key_origin
+            .get_blinding_private_key(&self.secp, &self.network)
+            .ok_or(KeyOriginError::RequiredUnblindingKey)?)
     }
 
     /// Proxies to the underlying key provider to get the confidential address.
-    #[must_use]
-    pub fn get_confidential_address(&self) -> Address {
-        self.key_origin.get_confidential_address(&self.secp, &self.network)
+    ///
+    /// # Errors
+    /// Returns a `SignerError` if the unblinding key or confidential address fails to derive.
+    pub fn get_confidential_address(&self) -> Result<Address, SignerError> {
+        Ok(self
+            .key_origin
+            .get_confidential_address(&self.secp, &self.network)
+            .ok_or(KeyOriginError::RequiredUnblindingKey)?)
     }
 
     /// Proxies to the underlying key provider to get the standard unblinded address.
@@ -248,7 +305,7 @@ impl<K: KeyOrigin> Signer<K> {
     /// # Errors
     /// Returns a `SignerError` if querying the network or unblinding operations fail.
     pub fn get_utxos(&self) -> Result<Vec<UTXO>, SignerError> {
-        self.get_utxos_filter(&|_| true, &|_| true)
+        self.get_utxos_filter(|_| true, |_| true)
     }
 
     /// Finds all known UTXOs belonging to the specific `AssetId`.
@@ -256,7 +313,7 @@ impl<K: KeyOrigin> Signer<K> {
     /// # Errors
     /// Returns a `SignerError` if network interaction or confidential output decryption fails.
     pub fn get_utxos_asset(&self, asset: AssetId) -> Result<Vec<UTXO>, SignerError> {
-        self.get_utxos_filter(&|utxo| utxo.asset() == asset, &|utxo| utxo.asset() == asset)
+        self.get_utxos_filter(move |utxo| utxo.asset() == asset, move |utxo| utxo.asset() == asset)
     }
 
     /// Finds all known UTXOs deriving from a targeted `Txid`.
@@ -265,7 +322,10 @@ impl<K: KeyOrigin> Signer<K> {
     /// Returns a `SignerError` if querying the network fails.
     // TODO: can this be optimized to not populate TxOuts that are filtered out?
     pub fn get_utxos_txid(&self, txid: Txid) -> Result<Vec<UTXO>, SignerError> {
-        self.get_utxos_filter(&|utxo| utxo.outpoint.txid == txid, &|utxo| utxo.outpoint.txid == txid)
+        self.get_utxos_filter(
+            move |utxo| utxo.outpoint.txid == txid,
+            move |utxo| utxo.outpoint.txid == txid,
+        )
     }
 
     /// Maps UTXOs retrieved from the provider through arbitrary functional filters.
@@ -275,47 +335,31 @@ impl<K: KeyOrigin> Signer<K> {
     /// Returns a `SignerError` if retrieving remote outputs or executing confidential node unblinding throws an error.
     pub fn get_utxos_filter(
         &self,
-        explicit_filter: &dyn Fn(&UTXO) -> bool,
-        confidential_filter: &dyn Fn(&UTXO) -> bool,
+        explicit_filter: impl Fn(&UTXO) -> bool,
+        confidential_filter: impl Fn(&UTXO) -> bool,
     ) -> Result<Vec<UTXO>, SignerError> {
-        // fetch explicit and confidential utxos
-        let mut all_utxos = self
-            .provider
-            .fetch_address_utxos(&self.key_origin.get_confidential_address(&self.secp, &self.network))?;
+        let confidential_addr = self.get_confidential_address()?;
+        let all_utxos = self.provider.fetch_address_utxos(&confidential_addr)?;
 
-        // filter out only confidential utxos and unblind them
-        let mut confidential_utxos = self.unblind(
-            all_utxos
-                .iter()
-                .filter(|utxo| utxo.txout.value.is_confidential())
-                .cloned()
-                .collect(),
-        )?;
-        // leave only explicit utxos
-        all_utxos.retain(|utxo| !utxo.txout.value.is_confidential());
+        // partition confidential and explicit utxos
+        let (confidential_utxos, mut explicit_utxos): (Vec<UTXO>, Vec<UTXO>) = all_utxos
+            .into_iter()
+            .partition(|utxo| utxo.txout.value.is_confidential());
 
-        all_utxos.retain(explicit_filter);
-        confidential_utxos.retain(confidential_filter);
+        let mut unblinded_utxos = self.unblind(confidential_utxos)?;
+
+        unblinded_utxos.retain(confidential_filter);
+        explicit_utxos.retain(explicit_filter);
 
         // push unblinded utxos to explicit ones
-        all_utxos.extend(confidential_utxos);
+        explicit_utxos.extend(unblinded_utxos);
 
-        Ok(all_utxos)
+        Ok(explicit_utxos)
     }
 
+    /// Proxies to the underlying key provider to get unblinded UTXOs.
     fn unblind(&self, utxos: Vec<UTXO>) -> Result<Vec<UTXO>, SignerError> {
-        let mut unblinded: Vec<UTXO> = Vec::new();
-
-        for mut utxo in utxos {
-            let blinding_key = self.get_blinding_private_key();
-            let secrets = utxo.txout.unblind(&self.secp, blinding_key.inner)?;
-
-            utxo.secrets = Some(secrets);
-
-            unblinded.push(utxo);
-        }
-
-        Ok(unblinded)
+        Ok(self.key_origin.unblind(&self.secp, &self.network, utxos)?)
     }
 
     fn estimate_tx(
@@ -425,44 +469,6 @@ impl<K: KeyOrigin> Signer<K> {
         Ok(pst.extract_tx()?)
     }
 
-    fn sign_program(
-        &self,
-        pst: &PartiallySignedTransaction,
-        program: &dyn ProgramTrait,
-        input_index: usize,
-        network: &SimplicityNetwork,
-    ) -> Result<schnorr::Signature, SignerError> {
-        let env = program.get_env(pst, input_index, network)?;
-        let msg = Message::from_digest(env.c_tx_env().sighash_all().to_byte_array());
-
-        let private_key = self.get_private_key();
-        let keypair = Keypair::from_secret_key(&self.secp, &private_key.inner);
-
-        Ok(self.secp.sign_schnorr(&msg, &keypair))
-    }
-
-    fn sign_input(
-        &self,
-        pst: &PartiallySignedTransaction,
-        input_index: usize,
-    ) -> Result<(PublicKey, ecdsa::Signature), SignerError> {
-        let tx = pst.extract_tx()?;
-
-        let mut sighash_cache = SighashCache::new(&tx);
-        let genesis_hash = elements_miniscript::elements::BlockHash::all_zeros();
-
-        let message = pst
-            .sighash_msg(input_index, &mut sighash_cache, None, genesis_hash)?
-            .to_secp_msg();
-
-        let private_key = self.get_private_key();
-        let public_key = private_key.public_key(&self.secp);
-
-        let signature = self.secp.sign_ecdsa_low_r(&message, &private_key.inner);
-
-        Ok((public_key, signature))
-    }
-
     fn get_signed_program_witness(
         &self,
         pst: &PartiallySignedTransaction,
@@ -545,6 +551,6 @@ mod tests {
         let signer = create_signer();
 
         println!("{}", signer.get_address());
-        println!("{}", signer.get_confidential_address());
+        println!("{}", signer.get_confidential_address().unwrap());
     }
 }

--- a/crates/sdk/src/signer/error.rs
+++ b/crates/sdk/src/signer/error.rs
@@ -16,17 +16,9 @@ pub enum SignerError {
     #[error(transparent)]
     WtnsInjectError(#[from] WtnsWrappingError),
 
-    /// Error indicating an incorrectly formatted mnemonic phrase.
-    #[error("Failed to parse a mnemonic: {0}")]
-    Mnemonic(String),
-
     /// Error thrown when PSET transaction extraction fails.
     #[error("Failed to extract tx from pst: {0}")]
     TxExtraction(#[from] simplicityhl::elements::pset::Error),
-
-    /// Error indicating failure to unblind a confidential transaction output.
-    #[error("Failed to unblind txout: {0}")]
-    Unblind(#[from] simplicityhl::elements::UnblindError),
 
     /// Error thrown when PSET blinding fails.
     #[error("Failed to blind a PST: {0}")]
@@ -52,22 +44,6 @@ pub enum SignerError {
     #[error("Invalid secret key")]
     InvalidSecretKey(#[from] simplicityhl::elements::secp256k1_zkp::UpstreamError),
 
-    /// Error thrown when HD wallet private key derivation fails.
-    #[error("Failed to derive a private key: {0}")]
-    PrivateKeyDerivation(#[from] elements_miniscript::bitcoin::bip32::Error),
-
-    /// Error thrown when constructing a derivation path string fails.
-    #[error("Failed to construct a derivation path: {0}")]
-    DerivationPath(String),
-
-    /// Error indicating failure to construct a valid WPKH (Witness Public Key Hash) descriptor.
-    #[error("Failed to construct a wpkh descriptor: {0}")]
-    WpkhDescriptor(String),
-
-    /// Error indicating failure to construct a valid SLIP77 blinding key descriptor.
-    #[error("Failed to construct a slip77 descriptor: {0}")]
-    Slip77Descriptor(String),
-
     /// Error thrown if there's a problem during descriptor conversion.
     #[error("Failed to convert a descriptor: {0}")]
     DescriptorConversion(#[from] elements_miniscript::descriptor::ConversionError),
@@ -79,6 +55,10 @@ pub enum SignerError {
     /// Error indicating an expected witness field could not be found.
     #[error("Missing such witness field: {0}")]
     WtnsFieldNotFound(String),
+
+    /// Error forwarded from `KeyOrigin`.
+    #[error(transparent)]
+    KeyOrigin(#[from] KeyOriginError),
 }
 
 /// Errors originating from manipulating witness paths and injecting values.
@@ -103,4 +83,36 @@ pub enum WtnsWrappingError {
     /// Error indicating that a path traversal attempted to reach an undefined or mismatched Either branch.
     #[error("Path reached undefined branch of Either")]
     EitherBranchMismatch,
+}
+
+/// Errors originating from manipulating witness paths and injecting values.
+#[derive(Debug, thiserror::Error)]
+pub enum KeyOriginError {
+    /// Error indicating an incorrectly formatted mnemonic phrase.
+    #[error("Failed to parse a mnemonic: {0}")]
+    Mnemonic(String),
+
+    /// Error thrown when constructing a derivation path string fails.
+    #[error("Failed to construct a derivation path: {0}")]
+    DerivationPath(String),
+
+    /// Error indicating failure to construct a valid SLIP77 blinding key descriptor.
+    #[error("Failed to construct a slip77 descriptor: {0}")]
+    Slip77Descriptor(String),
+
+    /// Error indicating failure to construct a valid WPKH (Witness Public Key Hash) descriptor.
+    #[error("Failed to construct a wpkh descriptor: {0}")]
+    WpkhDescriptor(String),
+
+    /// Error thrown when HD wallet private key derivation fails.
+    #[error("Failed to derive a private key: {0}")]
+    PrivateKeyDerivation(#[from] elements_miniscript::bitcoin::bip32::Error),
+
+    /// Error thrown when there is no pissibility to obtain a .
+    #[error("Required unblinding key, but it's empty")]
+    RequiredUnblindingKey,
+
+    /// Error indicating failure to unblind a confidential transaction output.
+    #[error("Failed to unblind txout: {0}")]
+    Unblind(#[from] simplicityhl::elements::UnblindError),
 }

--- a/crates/sdk/src/signer/key_origin.rs
+++ b/crates/sdk/src/signer/key_origin.rs
@@ -5,6 +5,7 @@ use bitcoincore_rpc::bitcoin::bip32::{DerivationPath, Fingerprint, Xpriv, Xpub};
 use bitcoincore_rpc::bitcoin::key::{Keypair, Secp256k1};
 use bitcoincore_rpc::bitcoin::secp256k1::{All, SecretKey};
 use bitcoincore_rpc::bitcoin::{NetworkKind, PrivateKey, PublicKey, XOnlyPublicKey};
+
 use elements_miniscript::elements::Address;
 use elements_miniscript::slip77::MasterBlindingKey;
 use elements_miniscript::{ConfidentialDescriptor, Descriptor, DescriptorPublicKey};

--- a/crates/sdk/src/signer/key_origin.rs
+++ b/crates/sdk/src/signer/key_origin.rs
@@ -1,0 +1,277 @@
+use std::str::FromStr;
+
+use bip39::Mnemonic;
+use bitcoincore_rpc::bitcoin::bip32::{DerivationPath, Fingerprint, Xpriv, Xpub};
+use bitcoincore_rpc::bitcoin::key::{Keypair, Secp256k1};
+use bitcoincore_rpc::bitcoin::secp256k1::{All, SecretKey};
+use bitcoincore_rpc::bitcoin::{NetworkKind, PrivateKey, PublicKey, XOnlyPublicKey};
+use elements_miniscript::elements::Address;
+use elements_miniscript::slip77::MasterBlindingKey;
+use elements_miniscript::{ConfidentialDescriptor, Descriptor, DescriptorPublicKey};
+
+use crate::provider::SimplicityNetwork;
+use crate::signer::SignerError;
+
+/// A generalized interface for providing cryptographic keys and addresses.
+///
+/// This trait abstracts the origin of the wallet's keys, allowing the `Signer` to remain
+/// agnostic to whether the keys are derived from a BIP39 mnemonic, a hardware wallet,
+/// or a single injected secret key.
+pub trait KeyOrigin {
+    /// Derives the X-Only public key specifically used for Schnorr and Taproot structures.
+    #[must_use]
+    fn get_schnorr_public_key(&self, secp: &Secp256k1<All>, network: &SimplicityNetwork) -> XOnlyPublicKey;
+
+    /// Resolves the standard format ECDSA public key.
+    #[must_use]
+    fn get_ecdsa_public_key(&self, secp: &Secp256k1<All>, network: &SimplicityNetwork) -> PublicKey;
+
+    /// Resolves the corresponding blinding public key.
+    #[must_use]
+    fn get_blinding_public_key(&self, secp: &Secp256k1<All>, network: &SimplicityNetwork) -> PublicKey;
+
+    /// Internally derives and exposes the wallet's signing active private key.
+    ///
+    /// # Panics
+    /// Panics if the master private key or derivation path cannot be derived.
+    #[must_use]
+    fn get_private_key(&self, secp: &Secp256k1<All>, network: &SimplicityNetwork) -> PrivateKey;
+
+    /// Generates the private key linked to confidential payload blinding.
+    ///
+    /// The generated `PrivateKey` is associated with the `Test` (non-Bitcoin-mainnet) network kind.
+    /// Retrieves the blinding private key derived from the master SLIP77 key and the script public key of the address.
+    ///
+    /// # Panics
+    /// Panics if the master SLIP77 key cannot be derived.
+    #[must_use]
+    fn get_blinding_private_key(&self, secp: &Secp256k1<All>, network: &SimplicityNetwork) -> PrivateKey;
+
+    /// Returns the confidential elements address matching the local wallet logic.
+    ///
+    /// # Panics
+    /// Panics if the SLIP77 descriptor cannot be generated or parsed, or if address derivation fails.
+    #[must_use]
+    fn get_confidential_address(&self, secp: &Secp256k1<All>, network: &SimplicityNetwork) -> Address;
+
+    /// Returns the standard unblinded address matching the local wallet logic.
+    ///
+    /// # Panics
+    /// Panics if the WPKH descriptor cannot be generated or parsed, or if address derivation fails.
+    #[must_use]
+    fn get_address(&self, secp: &Secp256k1<All>, network: &SimplicityNetwork) -> Address;
+}
+
+/// A Hierarchical Deterministic (HD) key provider based on BIP39 and SLIP77.
+///
+/// `HDKey` derives its key material from a standard mnemonic seed phrase.
+/// It handles BIP32 derivation paths for standard transaction signing and uses
+/// SLIP77 to generate deterministic blinding keys for confidential transactions
+/// on the Elements/Liquid network.
+pub struct HDKey {
+    xprv: Xpriv,
+    master_blinding: MasterBlindingKey,
+}
+
+impl HDKey {
+    /// Constructs a new `HDKey` from a BIP39 mnemonic phrase.
+    ///
+    /// # Errors
+    /// Returns a `SignerError::Mnemonic` if the provided phrase is invalid.
+    pub fn new(mnemonic: &str) -> Result<Self, SignerError> {
+        let mnemonic: Mnemonic = mnemonic
+            .parse()
+            .map_err(|e: bip39::Error| SignerError::Mnemonic(e.to_string()))?;
+        let seed = mnemonic.to_seed("");
+        let xprv = Xpriv::new_master(NetworkKind::Test, &seed)?;
+
+        let master_blinding_key = MasterBlindingKey::from_seed(&seed[..]);
+
+        Ok(Self {
+            master_blinding: master_blinding_key,
+            xprv,
+        })
+    }
+
+    fn derive_xpriv(&self, path: &DerivationPath, secp: &Secp256k1<All>) -> Result<Xpriv, SignerError> {
+        Ok(self.xprv.derive_priv(secp, path)?)
+    }
+
+    fn master_xpriv(&self, secp: &Secp256k1<All>) -> Result<Xpriv, SignerError> {
+        self.derive_xpriv(&DerivationPath::master(), secp)
+    }
+
+    fn derive_xpub(&self, path: &DerivationPath, secp: &Secp256k1<All>) -> Result<Xpub, SignerError> {
+        let derived = self.derive_xpriv(path, secp)?;
+
+        Ok(Xpub::from_priv(secp, &derived))
+    }
+
+    fn master_xpub(&self, secp: &Secp256k1<All>) -> Result<Xpub, SignerError> {
+        self.derive_xpub(&DerivationPath::master(), secp)
+    }
+
+    fn fingerprint(&self, secp: &Secp256k1<All>) -> Result<Fingerprint, SignerError> {
+        Ok(self.master_xpub(secp)?.fingerprint())
+    }
+
+    fn get_slip77_descriptor(&self, secp: &Secp256k1<All>, network: &SimplicityNetwork) -> Result<String, SignerError> {
+        let wpkh_descriptor = self.get_wpkh_descriptor(secp, network)?;
+        let blinding_key = self.master_blinding;
+
+        Ok(format!("ct(slip77({blinding_key}),{wpkh_descriptor})"))
+    }
+
+    fn get_wpkh_descriptor(&self, secp: &Secp256k1<All>, network: &SimplicityNetwork) -> Result<String, SignerError> {
+        let fingerprint = self.fingerprint(secp)?;
+        let path = self.get_derivation_path(network)?;
+        let xpub = self.derive_xpub(&path, secp)?;
+
+        Ok(format!("elwpkh([{fingerprint}/{path}]{xpub}/<0;1>/*)"))
+    }
+
+    #[allow(clippy::unused_self)]
+    fn get_derivation_path(&self, network: &SimplicityNetwork) -> Result<DerivationPath, SignerError> {
+        let coin_type = if network.is_mainnet() { 1776 } else { 1 };
+        let path = format!("84h/{coin_type}h/0h");
+
+        DerivationPath::from_str(&format!("m/{path}")).map_err(|e| SignerError::DerivationPath(e.to_string()))
+    }
+}
+
+impl KeyOrigin for HDKey {
+    fn get_schnorr_public_key(&self, secp: &Secp256k1<All>, network: &SimplicityNetwork) -> XOnlyPublicKey {
+        let private_key = self.get_private_key(secp, network);
+        let keypair = Keypair::from_secret_key(secp, &private_key.inner);
+
+        keypair.x_only_public_key().0
+    }
+
+    fn get_ecdsa_public_key(&self, secp: &Secp256k1<All>, network: &SimplicityNetwork) -> PublicKey {
+        self.get_private_key(secp, network).public_key(secp)
+    }
+
+    fn get_blinding_public_key(&self, secp: &Secp256k1<All>, network: &SimplicityNetwork) -> PublicKey {
+        self.get_blinding_private_key(secp, network).public_key(secp)
+    }
+
+    fn get_private_key(&self, secp: &Secp256k1<All>, network: &SimplicityNetwork) -> PrivateKey {
+        let master_xprv = self.master_xpriv(secp).unwrap();
+        let full_path = self.get_derivation_path(network).unwrap();
+
+        let derived = full_path.extend(
+            DerivationPath::from_str("0/1")
+                .map_err(|e| SignerError::DerivationPath(e.to_string()))
+                .unwrap(),
+        );
+
+        let ext_derived = master_xprv.derive_priv(secp, &derived).unwrap();
+
+        PrivateKey::new(ext_derived.private_key, NetworkKind::Test)
+    }
+
+    fn get_blinding_private_key(&self, secp: &Secp256k1<All>, network: &SimplicityNetwork) -> PrivateKey {
+        let blinding_key = self
+            .master_blinding
+            .blinding_private_key(&self.get_address(secp, network).script_pubkey());
+
+        PrivateKey::new(blinding_key, NetworkKind::Test)
+    }
+
+    fn get_confidential_address(&self, secp: &Secp256k1<All>, network: &SimplicityNetwork) -> Address {
+        let mut descriptor = ConfidentialDescriptor::<DescriptorPublicKey>::from_str(
+            &self.get_slip77_descriptor(secp, network).unwrap(),
+        )
+        .map_err(|e| SignerError::Slip77Descriptor(e.to_string()))
+        .unwrap();
+
+        // confidential descriptor doesn't support multipath
+        descriptor.descriptor = descriptor.descriptor.into_single_descriptors().unwrap()[0].clone();
+
+        descriptor
+            .at_derivation_index(1)
+            .unwrap()
+            .address(secp, network.address_params())
+            .unwrap()
+    }
+
+    fn get_address(&self, secp: &Secp256k1<All>, network: &SimplicityNetwork) -> Address {
+        let descriptor = Descriptor::<DescriptorPublicKey>::from_str(&self.get_wpkh_descriptor(secp, network).unwrap())
+            .map_err(|e| SignerError::WpkhDescriptor(e.to_string()))
+            .unwrap();
+
+        descriptor.into_single_descriptors().unwrap()[0]
+            .at_derivation_index(1)
+            .unwrap()
+            .address(network.address_params())
+            .unwrap()
+    }
+}
+
+/// A simplified key provider powered by a single static secret key.
+///
+/// Unlike `HDKey` which derives paths hierarchically, `SingleKey` uses
+/// exactly one `SecretKey` for all signing operations. It can optionally accept a
+/// `MasterBlindingKey` to support confidential transactions and blinded addresses.
+pub struct SingleKey {
+    secret_key: SecretKey,
+    blinding_key: Option<MasterBlindingKey>,
+}
+
+impl SingleKey {
+    /// Creates a new `SingleKey`.
+    ///
+    /// # Arguments
+    /// * `secret_key` - The base static secret key used for ECDSA and Schnorr signatures.
+    /// * `blinding_key` - An optional SLIP77 master blinding key.
+    #[must_use]
+    pub fn new(secret_key: SecretKey, blinding_key: Option<MasterBlindingKey>) -> Self {
+        Self {
+            secret_key,
+            blinding_key,
+        }
+    }
+}
+
+impl KeyOrigin for SingleKey {
+    fn get_schnorr_public_key(&self, secp: &Secp256k1<All>, _network: &SimplicityNetwork) -> XOnlyPublicKey {
+        let keypair = Keypair::from_secret_key(secp, &self.secret_key);
+        keypair.x_only_public_key().0
+    }
+
+    fn get_ecdsa_public_key(&self, secp: &Secp256k1<All>, network: &SimplicityNetwork) -> PublicKey {
+        self.get_private_key(secp, network).public_key(secp)
+    }
+
+    fn get_blinding_public_key(&self, secp: &Secp256k1<All>, network: &SimplicityNetwork) -> PublicKey {
+        self.get_blinding_private_key(secp, network).public_key(secp)
+    }
+
+    fn get_private_key(&self, _secp: &Secp256k1<All>, _network: &SimplicityNetwork) -> PrivateKey {
+        PrivateKey::new(self.secret_key, NetworkKind::Test)
+    }
+
+    fn get_blinding_private_key(&self, secp: &Secp256k1<All>, network: &SimplicityNetwork) -> PrivateKey {
+        let master_blinding = self
+            .blinding_key
+            .expect("Blinding key is required for confidential operations");
+
+        let script_pubkey = self.get_address(secp, network).script_pubkey();
+        let blinding_key = master_blinding.blinding_private_key(&script_pubkey);
+
+        PrivateKey::new(blinding_key, NetworkKind::Test)
+    }
+
+    fn get_confidential_address(&self, secp: &Secp256k1<All>, network: &SimplicityNetwork) -> Address {
+        let ecdsa_pubkey = self.get_ecdsa_public_key(secp, network);
+        let blinding_pubkey = self.get_blinding_public_key(secp, network);
+
+        Address::p2wpkh(&ecdsa_pubkey, Some(blinding_pubkey.inner), network.address_params())
+    }
+
+    fn get_address(&self, secp: &Secp256k1<All>, network: &SimplicityNetwork) -> Address {
+        let ecdsa_pubkey = self.get_ecdsa_public_key(secp, network);
+
+        Address::p2wpkh(&ecdsa_pubkey, None, network.address_params())
+    }
+}

--- a/crates/sdk/src/signer/key_origin.rs
+++ b/crates/sdk/src/signer/key_origin.rs
@@ -11,7 +11,8 @@ use elements_miniscript::slip77::MasterBlindingKey;
 use elements_miniscript::{ConfidentialDescriptor, Descriptor, DescriptorPublicKey};
 
 use crate::provider::SimplicityNetwork;
-use crate::signer::SignerError;
+use crate::signer::error::KeyOriginError;
+use crate::transaction::UTXO;
 
 /// A generalized interface for providing cryptographic keys and addresses.
 ///
@@ -29,7 +30,7 @@ pub trait KeyOrigin {
 
     /// Resolves the corresponding blinding public key.
     #[must_use]
-    fn get_blinding_public_key(&self, secp: &Secp256k1<All>, network: &SimplicityNetwork) -> PublicKey;
+    fn get_blinding_public_key(&self, secp: &Secp256k1<All>, network: &SimplicityNetwork) -> Option<PublicKey>;
 
     /// Internally derives and exposes the wallet's signing active private key.
     ///
@@ -46,14 +47,14 @@ pub trait KeyOrigin {
     /// # Panics
     /// Panics if the master SLIP77 key cannot be derived.
     #[must_use]
-    fn get_blinding_private_key(&self, secp: &Secp256k1<All>, network: &SimplicityNetwork) -> PrivateKey;
+    fn get_blinding_private_key(&self, secp: &Secp256k1<All>, network: &SimplicityNetwork) -> Option<PrivateKey>;
 
     /// Returns the confidential elements address matching the local wallet logic.
     ///
     /// # Panics
     /// Panics if the SLIP77 descriptor cannot be generated or parsed, or if address derivation fails.
     #[must_use]
-    fn get_confidential_address(&self, secp: &Secp256k1<All>, network: &SimplicityNetwork) -> Address;
+    fn get_confidential_address(&self, secp: &Secp256k1<All>, network: &SimplicityNetwork) -> Option<Address>;
 
     /// Returns the standard unblinded address matching the local wallet logic.
     ///
@@ -61,6 +62,17 @@ pub trait KeyOrigin {
     /// Panics if the WPKH descriptor cannot be generated or parsed, or if address derivation fails.
     #[must_use]
     fn get_address(&self, secp: &Secp256k1<All>, network: &SimplicityNetwork) -> Address;
+
+    /// Unblinds a list of transaction outputs (UTXOs) using the blinding keys.
+    ///
+    /// # Errors
+    /// Returns a `KeyOriginError` if the blinding keys cannot be resolved or if unblinding fails.
+    fn unblind(
+        &self,
+        secp: &Secp256k1<All>,
+        network: &SimplicityNetwork,
+        utxos: Vec<UTXO>,
+    ) -> Result<Vec<UTXO>, KeyOriginError>;
 }
 
 /// A Hierarchical Deterministic (HD) key provider based on BIP39 and SLIP77.
@@ -78,11 +90,11 @@ impl HDKey {
     /// Constructs a new `HDKey` from a BIP39 mnemonic phrase.
     ///
     /// # Errors
-    /// Returns a `SignerError::Mnemonic` if the provided phrase is invalid.
-    pub fn new(mnemonic: &str) -> Result<Self, SignerError> {
+    /// Returns a `KeyOriginError::Mnemonic` if the provided phrase is invalid.
+    pub fn new(mnemonic: &str) -> Result<Self, KeyOriginError> {
         let mnemonic: Mnemonic = mnemonic
             .parse()
-            .map_err(|e: bip39::Error| SignerError::Mnemonic(e.to_string()))?;
+            .map_err(|e: bip39::Error| KeyOriginError::Mnemonic(e.to_string()))?;
         let seed = mnemonic.to_seed("");
         let xprv = Xpriv::new_master(NetworkKind::Test, &seed)?;
 
@@ -94,36 +106,44 @@ impl HDKey {
         })
     }
 
-    fn derive_xpriv(&self, path: &DerivationPath, secp: &Secp256k1<All>) -> Result<Xpriv, SignerError> {
+    fn derive_xpriv(&self, path: &DerivationPath, secp: &Secp256k1<All>) -> Result<Xpriv, KeyOriginError> {
         Ok(self.xprv.derive_priv(secp, path)?)
     }
 
-    fn master_xpriv(&self, secp: &Secp256k1<All>) -> Result<Xpriv, SignerError> {
+    fn master_xpriv(&self, secp: &Secp256k1<All>) -> Result<Xpriv, KeyOriginError> {
         self.derive_xpriv(&DerivationPath::master(), secp)
     }
 
-    fn derive_xpub(&self, path: &DerivationPath, secp: &Secp256k1<All>) -> Result<Xpub, SignerError> {
+    fn derive_xpub(&self, path: &DerivationPath, secp: &Secp256k1<All>) -> Result<Xpub, KeyOriginError> {
         let derived = self.derive_xpriv(path, secp)?;
 
         Ok(Xpub::from_priv(secp, &derived))
     }
 
-    fn master_xpub(&self, secp: &Secp256k1<All>) -> Result<Xpub, SignerError> {
+    fn master_xpub(&self, secp: &Secp256k1<All>) -> Result<Xpub, KeyOriginError> {
         self.derive_xpub(&DerivationPath::master(), secp)
     }
 
-    fn fingerprint(&self, secp: &Secp256k1<All>) -> Result<Fingerprint, SignerError> {
+    fn fingerprint(&self, secp: &Secp256k1<All>) -> Result<Fingerprint, KeyOriginError> {
         Ok(self.master_xpub(secp)?.fingerprint())
     }
 
-    fn get_slip77_descriptor(&self, secp: &Secp256k1<All>, network: &SimplicityNetwork) -> Result<String, SignerError> {
+    fn get_slip77_descriptor(
+        &self,
+        secp: &Secp256k1<All>,
+        network: &SimplicityNetwork,
+    ) -> Result<String, KeyOriginError> {
         let wpkh_descriptor = self.get_wpkh_descriptor(secp, network)?;
         let blinding_key = self.master_blinding;
 
         Ok(format!("ct(slip77({blinding_key}),{wpkh_descriptor})"))
     }
 
-    fn get_wpkh_descriptor(&self, secp: &Secp256k1<All>, network: &SimplicityNetwork) -> Result<String, SignerError> {
+    fn get_wpkh_descriptor(
+        &self,
+        secp: &Secp256k1<All>,
+        network: &SimplicityNetwork,
+    ) -> Result<String, KeyOriginError> {
         let fingerprint = self.fingerprint(secp)?;
         let path = self.get_derivation_path(network)?;
         let xpub = self.derive_xpub(&path, secp)?;
@@ -132,11 +152,11 @@ impl HDKey {
     }
 
     #[allow(clippy::unused_self)]
-    fn get_derivation_path(&self, network: &SimplicityNetwork) -> Result<DerivationPath, SignerError> {
+    fn get_derivation_path(&self, network: &SimplicityNetwork) -> Result<DerivationPath, KeyOriginError> {
         let coin_type = if network.is_mainnet() { 1776 } else { 1 };
         let path = format!("84h/{coin_type}h/0h");
 
-        DerivationPath::from_str(&format!("m/{path}")).map_err(|e| SignerError::DerivationPath(e.to_string()))
+        DerivationPath::from_str(&format!("m/{path}")).map_err(|e| KeyOriginError::DerivationPath(e.to_string()))
     }
 }
 
@@ -152,8 +172,8 @@ impl KeyOrigin for HDKey {
         self.get_private_key(secp, network).public_key(secp)
     }
 
-    fn get_blinding_public_key(&self, secp: &Secp256k1<All>, network: &SimplicityNetwork) -> PublicKey {
-        self.get_blinding_private_key(secp, network).public_key(secp)
+    fn get_blinding_public_key(&self, secp: &Secp256k1<All>, network: &SimplicityNetwork) -> Option<PublicKey> {
+        Some(self.get_blinding_private_key(secp, network).unwrap().public_key(secp))
     }
 
     fn get_private_key(&self, secp: &Secp256k1<All>, network: &SimplicityNetwork) -> PrivateKey {
@@ -162,7 +182,7 @@ impl KeyOrigin for HDKey {
 
         let derived = full_path.extend(
             DerivationPath::from_str("0/1")
-                .map_err(|e| SignerError::DerivationPath(e.to_string()))
+                .map_err(|e| KeyOriginError::DerivationPath(e.to_string()))
                 .unwrap(),
         );
 
@@ -171,34 +191,36 @@ impl KeyOrigin for HDKey {
         PrivateKey::new(ext_derived.private_key, NetworkKind::Test)
     }
 
-    fn get_blinding_private_key(&self, secp: &Secp256k1<All>, network: &SimplicityNetwork) -> PrivateKey {
+    fn get_blinding_private_key(&self, secp: &Secp256k1<All>, network: &SimplicityNetwork) -> Option<PrivateKey> {
         let blinding_key = self
             .master_blinding
             .blinding_private_key(&self.get_address(secp, network).script_pubkey());
 
-        PrivateKey::new(blinding_key, NetworkKind::Test)
+        Some(PrivateKey::new(blinding_key, NetworkKind::Test))
     }
 
-    fn get_confidential_address(&self, secp: &Secp256k1<All>, network: &SimplicityNetwork) -> Address {
+    fn get_confidential_address(&self, secp: &Secp256k1<All>, network: &SimplicityNetwork) -> Option<Address> {
         let mut descriptor = ConfidentialDescriptor::<DescriptorPublicKey>::from_str(
             &self.get_slip77_descriptor(secp, network).unwrap(),
         )
-        .map_err(|e| SignerError::Slip77Descriptor(e.to_string()))
+        .map_err(|e| KeyOriginError::Slip77Descriptor(e.to_string()))
         .unwrap();
 
         // confidential descriptor doesn't support multipath
         descriptor.descriptor = descriptor.descriptor.into_single_descriptors().unwrap()[0].clone();
 
-        descriptor
-            .at_derivation_index(1)
-            .unwrap()
-            .address(secp, network.address_params())
-            .unwrap()
+        Some(
+            descriptor
+                .at_derivation_index(1)
+                .unwrap()
+                .address(secp, network.address_params())
+                .unwrap(),
+        )
     }
 
     fn get_address(&self, secp: &Secp256k1<All>, network: &SimplicityNetwork) -> Address {
         let descriptor = Descriptor::<DescriptorPublicKey>::from_str(&self.get_wpkh_descriptor(secp, network).unwrap())
-            .map_err(|e| SignerError::WpkhDescriptor(e.to_string()))
+            .map_err(|e| KeyOriginError::WpkhDescriptor(e.to_string()))
             .unwrap();
 
         descriptor.into_single_descriptors().unwrap()[0]
@@ -206,6 +228,26 @@ impl KeyOrigin for HDKey {
             .unwrap()
             .address(network.address_params())
             .unwrap()
+    }
+
+    fn unblind(
+        &self,
+        secp: &Secp256k1<All>,
+        network: &SimplicityNetwork,
+        utxos: Vec<UTXO>,
+    ) -> Result<Vec<UTXO>, KeyOriginError> {
+        let blinding_key = self.get_blinding_private_key(secp, network).unwrap();
+        let mut unblinded: Vec<UTXO> = Vec::with_capacity(utxos.len());
+
+        for mut utxo in utxos {
+            let secrets = utxo.txout.unblind(secp, blinding_key.inner)?;
+
+            utxo.secrets = Some(secrets);
+
+            unblinded.push(utxo);
+        }
+
+        Ok(unblinded)
     }
 }
 
@@ -244,35 +286,59 @@ impl KeyOrigin for SingleKey {
         self.get_private_key(secp, network).public_key(secp)
     }
 
-    fn get_blinding_public_key(&self, secp: &Secp256k1<All>, network: &SimplicityNetwork) -> PublicKey {
-        self.get_blinding_private_key(secp, network).public_key(secp)
+    fn get_blinding_public_key(&self, secp: &Secp256k1<All>, network: &SimplicityNetwork) -> Option<PublicKey> {
+        self.get_blinding_private_key(secp, network).map(|x| x.public_key(secp))
     }
 
     fn get_private_key(&self, _secp: &Secp256k1<All>, _network: &SimplicityNetwork) -> PrivateKey {
         PrivateKey::new(self.secret_key, NetworkKind::Test)
     }
 
-    fn get_blinding_private_key(&self, secp: &Secp256k1<All>, network: &SimplicityNetwork) -> PrivateKey {
-        let master_blinding = self
-            .blinding_key
-            .expect("Blinding key is required for confidential operations");
+    fn get_blinding_private_key(&self, secp: &Secp256k1<All>, network: &SimplicityNetwork) -> Option<PrivateKey> {
+        let master_blinding = self.blinding_key?;
 
         let script_pubkey = self.get_address(secp, network).script_pubkey();
         let blinding_key = master_blinding.blinding_private_key(&script_pubkey);
 
-        PrivateKey::new(blinding_key, NetworkKind::Test)
+        Some(PrivateKey::new(blinding_key, NetworkKind::Test))
     }
 
-    fn get_confidential_address(&self, secp: &Secp256k1<All>, network: &SimplicityNetwork) -> Address {
+    fn get_confidential_address(&self, secp: &Secp256k1<All>, network: &SimplicityNetwork) -> Option<Address> {
+        let blinding_pubkey = self.get_blinding_public_key(secp, network)?;
         let ecdsa_pubkey = self.get_ecdsa_public_key(secp, network);
-        let blinding_pubkey = self.get_blinding_public_key(secp, network);
 
-        Address::p2wpkh(&ecdsa_pubkey, Some(blinding_pubkey.inner), network.address_params())
+        Some(Address::p2wpkh(
+            &ecdsa_pubkey,
+            Some(blinding_pubkey.inner),
+            network.address_params(),
+        ))
     }
 
     fn get_address(&self, secp: &Secp256k1<All>, network: &SimplicityNetwork) -> Address {
         let ecdsa_pubkey = self.get_ecdsa_public_key(secp, network);
 
         Address::p2wpkh(&ecdsa_pubkey, None, network.address_params())
+    }
+
+    fn unblind(
+        &self,
+        secp: &Secp256k1<All>,
+        network: &SimplicityNetwork,
+        utxos: Vec<UTXO>,
+    ) -> Result<Vec<UTXO>, KeyOriginError> {
+        let blinding_key = self
+            .get_blinding_private_key(secp, network)
+            .ok_or(KeyOriginError::RequiredUnblindingKey)?;
+        let mut unblinded: Vec<UTXO> = Vec::with_capacity(utxos.len());
+
+        for mut utxo in utxos {
+            let secrets = utxo.txout.unblind(secp, blinding_key.inner)?;
+
+            utxo.secrets = Some(secrets);
+
+            unblinded.push(utxo);
+        }
+
+        Ok(unblinded)
     }
 }

--- a/crates/sdk/src/signer/key_origin.rs
+++ b/crates/sdk/src/signer/key_origin.rs
@@ -91,8 +91,9 @@ impl HDKey {
     ///
     /// # Errors
     /// Returns a `KeyOriginError::Mnemonic` if the provided phrase is invalid.
-    pub fn new(mnemonic: &str) -> Result<Self, KeyOriginError> {
+    pub fn new(mnemonic: impl AsRef<str>) -> Result<Self, KeyOriginError> {
         let mnemonic: Mnemonic = mnemonic
+            .as_ref()
             .parse()
             .map_err(|e: bip39::Error| KeyOriginError::Mnemonic(e.to_string()))?;
         let seed = mnemonic.to_seed("");
@@ -324,11 +325,13 @@ impl KeyOrigin for SingleKey {
         &self,
         secp: &Secp256k1<All>,
         network: &SimplicityNetwork,
-        utxos: Vec<UTXO>,
+        mut utxos: Vec<UTXO>,
     ) -> Result<Vec<UTXO>, KeyOriginError> {
-        let blinding_key = self
-            .get_blinding_private_key(secp, network)
-            .ok_or(KeyOriginError::RequiredUnblindingKey)?;
+        let Some(blinding_key) = self.get_blinding_private_key(secp, network) else {
+            utxos.clear();
+            return Ok(utxos);
+        };
+
         let mut unblinded: Vec<UTXO> = Vec::with_capacity(utxos.len());
 
         for mut utxo in utxos {

--- a/crates/sdk/src/signer/mod.rs
+++ b/crates/sdk/src/signer/mod.rs
@@ -5,5 +5,5 @@ pub mod error;
 /// Utilities for injecting witness data bindings into Simplicity environments.
 mod wtns_injector;
 
-pub use core::{HDKeyOrigin, KeyProvider, Signer, SignerTrait, SingleKeyOrigin};
+pub use core::{HDKey, KeyOrigin, Signer, SignerTrait, SingleKey};
 pub use error::SignerError;

--- a/crates/sdk/src/signer/mod.rs
+++ b/crates/sdk/src/signer/mod.rs
@@ -2,8 +2,11 @@
 pub mod core;
 /// Signer-specific error enumerations capturing execution constraints and mapping internal failure types.
 pub mod error;
+/// Contains abstractions that allow the `Signer` to remain agnostic to the origin of its keys.
+mod key_origin;
 /// Utilities for injecting witness data bindings into Simplicity environments.
 mod wtns_injector;
 
-pub use core::{HDKey, KeyOrigin, Signer, SignerTrait, SingleKey};
+pub use core::{Signer, SignerTrait};
 pub use error::SignerError;
+pub use key_origin::{HDKey, KeyOrigin, SingleKey};

--- a/crates/sdk/src/signer/mod.rs
+++ b/crates/sdk/src/signer/mod.rs
@@ -5,5 +5,5 @@ pub mod error;
 /// Utilities for injecting witness data bindings into Simplicity environments.
 mod wtns_injector;
 
-pub use core::{Signer, SignerTrait};
+pub use core::{HDKeyOrigin, KeyProvider, Signer, SignerTrait, SingleKeyOrigin};
 pub use error::SignerError;

--- a/crates/test/src/context.rs
+++ b/crates/test/src/context.rs
@@ -59,8 +59,7 @@ impl TestContext {
             ))
         };
 
-        let hd_key_origin = HDKey::new(mnemonic).unwrap();
-        Signer::new(hd_key_origin, provider)
+        Signer::new(HDKey::new(mnemonic).unwrap(), provider)
     }
 
     pub fn random_signer(&self) -> Signer<HDKey> {
@@ -123,8 +122,7 @@ impl TestContext {
                         elements_url: Some(rpc.url),
                         auth: Some(auth),
                     };
-                    let hd_key_origin = HDKey::new(config.mnemonic.as_str()).unwrap();
-                    signer = Signer::new(hd_key_origin, provider);
+                    signer = Signer::new(HDKey::new(config.mnemonic.as_str()).unwrap(), provider);
                     client = None;
                 }
                 None => {
@@ -142,8 +140,7 @@ impl TestContext {
                         elements_url: None,
                         auth: None,
                     };
-                    let hd_key_origin = HDKey::new(config.mnemonic.as_str()).unwrap();
-                    signer = Signer::new(hd_key_origin, provider);
+                    signer = Signer::new(HDKey::new(config.mnemonic.as_str()).unwrap(), provider);
                     client = None;
                 }
             },

--- a/crates/test/src/context.rs
+++ b/crates/test/src/context.rs
@@ -9,7 +9,7 @@ use smplx_sdk::global::GlobalConfig;
 use smplx_sdk::provider::{
     ElementsRpc, EsploraProvider, ProviderInfo, ProviderTrait, SimplexProvider, SimplicityNetwork,
 };
-use smplx_sdk::signer::{HDKeyOrigin, Signer};
+use smplx_sdk::signer::{HDKey, Signer};
 use smplx_sdk::utils::random_mnemonic;
 
 use crate::config::TestConfig;
@@ -22,7 +22,7 @@ pub struct TestContext {
     // since providers can't be cloned, we need this variable to create new signers
     _provider_info: ProviderInfo,
     config: TestConfig,
-    signer: Signer<HDKeyOrigin>,
+    signer: Signer<HDKey>,
 }
 
 impl TestContext {
@@ -42,7 +42,7 @@ impl TestContext {
         })
     }
 
-    pub fn create_signer(&self, mnemonic: &str) -> Signer<HDKeyOrigin> {
+    pub fn create_signer(&self, mnemonic: &str) -> Signer<HDKey> {
         let provider: Box<dyn ProviderTrait> = if self._provider_info.elements_url.is_some() {
             // local regtest or external regtest
             Box::new(SimplexProvider::new(
@@ -59,15 +59,15 @@ impl TestContext {
             ))
         };
 
-        let hd_key_origin = HDKeyOrigin::new(mnemonic).unwrap();
+        let hd_key_origin = HDKey::new(mnemonic).unwrap();
         Signer::new(hd_key_origin, provider)
     }
 
-    pub fn random_signer(&self) -> Signer<HDKeyOrigin> {
+    pub fn random_signer(&self) -> Signer<HDKey> {
         self.create_signer(random_mnemonic().as_str())
     }
 
-    pub fn get_default_signer(&self) -> &Signer<HDKeyOrigin> {
+    pub fn get_default_signer(&self) -> &Signer<HDKey> {
         &self.signer
     }
 
@@ -101,10 +101,10 @@ impl TestContext {
         NetworkUtils::new(regtest_rpc, esplora)
     }
 
-    fn setup(config: &TestConfig) -> Result<(Signer<HDKeyOrigin>, ProviderInfo, Option<RegtestClient>), TestError> {
+    fn setup(config: &TestConfig) -> Result<(Signer<HDKey>, ProviderInfo, Option<RegtestClient>), TestError> {
         let client: Option<RegtestClient>;
         let provider_info: ProviderInfo;
-        let signer: Signer<HDKeyOrigin>;
+        let signer: Signer<HDKey>;
 
         match config.esplora.clone() {
             Some(esplora) => match config.rpc.clone() {
@@ -123,7 +123,7 @@ impl TestContext {
                         elements_url: Some(rpc.url),
                         auth: Some(auth),
                     };
-                    let hd_key_origin = HDKeyOrigin::new(config.mnemonic.as_str()).unwrap();
+                    let hd_key_origin = HDKey::new(config.mnemonic.as_str()).unwrap();
                     signer = Signer::new(hd_key_origin, provider);
                     client = None;
                 }
@@ -142,7 +142,7 @@ impl TestContext {
                         elements_url: None,
                         auth: None,
                     };
-                    let hd_key_origin = HDKeyOrigin::new(config.mnemonic.as_str()).unwrap();
+                    let hd_key_origin = HDKey::new(config.mnemonic.as_str()).unwrap();
                     signer = Signer::new(hd_key_origin, provider);
                     client = None;
                 }

--- a/crates/test/src/context.rs
+++ b/crates/test/src/context.rs
@@ -9,7 +9,7 @@ use smplx_sdk::global::GlobalConfig;
 use smplx_sdk::provider::{
     ElementsRpc, EsploraProvider, ProviderInfo, ProviderTrait, SimplexProvider, SimplicityNetwork,
 };
-use smplx_sdk::signer::Signer;
+use smplx_sdk::signer::{HDKeyOrigin, Signer};
 use smplx_sdk::utils::random_mnemonic;
 
 use crate::config::TestConfig;
@@ -22,7 +22,7 @@ pub struct TestContext {
     // since providers can't be cloned, we need this variable to create new signers
     _provider_info: ProviderInfo,
     config: TestConfig,
-    signer: Signer,
+    signer: Signer<HDKeyOrigin>,
 }
 
 impl TestContext {
@@ -42,7 +42,7 @@ impl TestContext {
         })
     }
 
-    pub fn create_signer(&self, mnemonic: &str) -> Signer {
+    pub fn create_signer(&self, mnemonic: &str) -> Signer<HDKeyOrigin> {
         let provider: Box<dyn ProviderTrait> = if self._provider_info.elements_url.is_some() {
             // local regtest or external regtest
             Box::new(SimplexProvider::new(
@@ -59,14 +59,15 @@ impl TestContext {
             ))
         };
 
-        Signer::new(mnemonic, provider)
+        let hd_key_origin = HDKeyOrigin::new(mnemonic).unwrap();
+        Signer::new(hd_key_origin, provider)
     }
 
-    pub fn random_signer(&self) -> Signer {
+    pub fn random_signer(&self) -> Signer<HDKeyOrigin> {
         self.create_signer(random_mnemonic().as_str())
     }
 
-    pub fn get_default_signer(&self) -> &Signer {
+    pub fn get_default_signer(&self) -> &Signer<HDKeyOrigin> {
         &self.signer
     }
 
@@ -100,10 +101,10 @@ impl TestContext {
         NetworkUtils::new(regtest_rpc, esplora)
     }
 
-    fn setup(config: &TestConfig) -> Result<(Signer, ProviderInfo, Option<RegtestClient>), TestError> {
+    fn setup(config: &TestConfig) -> Result<(Signer<HDKeyOrigin>, ProviderInfo, Option<RegtestClient>), TestError> {
         let client: Option<RegtestClient>;
         let provider_info: ProviderInfo;
-        let signer: Signer;
+        let signer: Signer<HDKeyOrigin>;
 
         match config.esplora.clone() {
             Some(esplora) => match config.rpc.clone() {
@@ -122,7 +123,8 @@ impl TestContext {
                         elements_url: Some(rpc.url),
                         auth: Some(auth),
                     };
-                    signer = Signer::new(config.mnemonic.as_str(), provider);
+                    let hd_key_origin = HDKeyOrigin::new(config.mnemonic.as_str()).unwrap();
+                    signer = Signer::new(hd_key_origin, provider);
                     client = None;
                 }
                 None => {
@@ -140,7 +142,8 @@ impl TestContext {
                         elements_url: None,
                         auth: None,
                     };
-                    signer = Signer::new(config.mnemonic.as_str(), provider);
+                    let hd_key_origin = HDKeyOrigin::new(config.mnemonic.as_str()).unwrap();
+                    signer = Signer::new(hd_key_origin, provider);
                     client = None;
                 }
             },

--- a/examples/basic/tests/confidential_test.rs
+++ b/examples/basic/tests/confidential_test.rs
@@ -1,10 +1,14 @@
 use simplex::simplicityhl::elements::AssetId;
 
-use simplex::signer::Signer;
+use simplex::signer::{KeyProvider, Signer};
 use simplex::transaction::partial_input::IssuanceInput;
 use simplex::transaction::{FinalTransaction, PartialInput, PartialOutput, RequiredSignature, TxReceipt};
 
-fn make_confidential_to_bob<'a>(alice: &'a Signer, bob: &Signer, asset: AssetId) -> anyhow::Result<TxReceipt<'a>> {
+fn make_confidential_to_bob<'a, K1: KeyProvider, K2: KeyProvider>(
+    alice: &'a Signer<K1>,
+    bob: &Signer<K2>,
+    asset: AssetId,
+) -> anyhow::Result<TxReceipt<'a>> {
     let mut ft = FinalTransaction::new();
 
     ft.add_output(
@@ -18,7 +22,10 @@ fn make_confidential_to_bob<'a>(alice: &'a Signer, bob: &Signer, asset: AssetId)
     Ok(tx_receipt)
 }
 
-fn issue_confidential_to_alice<'a>(alice: &Signer, bob: &'a Signer) -> anyhow::Result<TxReceipt<'a>> {
+fn issue_confidential_to_alice<'a, K1: KeyProvider, K2: KeyProvider>(
+    alice: &Signer<K1>,
+    bob: &'a Signer<K2>,
+) -> anyhow::Result<TxReceipt<'a>> {
     let utxos = bob.get_utxos()?;
 
     let mut ft = FinalTransaction::new();

--- a/examples/basic/tests/confidential_test.rs
+++ b/examples/basic/tests/confidential_test.rs
@@ -1,10 +1,10 @@
 use simplex::simplicityhl::elements::AssetId;
 
-use simplex::signer::{KeyProvider, Signer};
+use simplex::signer::{KeyOrigin, Signer};
 use simplex::transaction::partial_input::IssuanceInput;
 use simplex::transaction::{FinalTransaction, PartialInput, PartialOutput, RequiredSignature, TxReceipt};
 
-fn make_confidential_to_bob<'a, K1: KeyProvider, K2: KeyProvider>(
+fn make_confidential_to_bob<'a, K1: KeyOrigin, K2: KeyOrigin>(
     alice: &'a Signer<K1>,
     bob: &Signer<K2>,
     asset: AssetId,
@@ -22,7 +22,7 @@ fn make_confidential_to_bob<'a, K1: KeyProvider, K2: KeyProvider>(
     Ok(tx_receipt)
 }
 
-fn issue_confidential_to_alice<'a, K1: KeyProvider, K2: KeyProvider>(
+fn issue_confidential_to_alice<'a, K1: KeyOrigin, K2: KeyOrigin>(
     alice: &Signer<K1>,
     bob: &'a Signer<K2>,
 ) -> anyhow::Result<TxReceipt<'a>> {

--- a/examples/basic/tests/confidential_test.rs
+++ b/examples/basic/tests/confidential_test.rs
@@ -13,7 +13,7 @@ fn make_confidential_to_bob<'a, K1: KeyOrigin, K2: KeyOrigin>(
 
     ft.add_output(
         PartialOutput::new(bob.get_address().script_pubkey(), 1000, asset)
-            .with_blinding_key(bob.get_blinding_public_key()),
+            .with_blinding_key(bob.get_blinding_public_key()?),
     );
 
     let tx_receipt = alice.broadcast(&ft)?;
@@ -38,7 +38,7 @@ fn issue_confidential_to_alice<'a, K1: KeyOrigin, K2: KeyOrigin>(
 
     ft.add_output(
         PartialOutput::new(alice.get_address().script_pubkey(), 1000, issuance_details.asset_id)
-            .with_blinding_key(alice.get_blinding_public_key()),
+            .with_blinding_key(alice.get_blinding_public_key()?),
     );
     ft.add_output(
         PartialOutput::new(
@@ -46,7 +46,7 @@ fn issue_confidential_to_alice<'a, K1: KeyOrigin, K2: KeyOrigin>(
             100,
             issuance_details.inflation_asset_id,
         )
-        .with_blinding_key(alice.get_blinding_public_key()),
+        .with_blinding_key(alice.get_blinding_public_key()?),
     );
 
     let tx_receipt = bob.broadcast(&ft)?;

--- a/fixtures/tests/confidential_test.rs
+++ b/fixtures/tests/confidential_test.rs
@@ -1,10 +1,10 @@
 use simplex::simplicityhl::elements::AssetId;
 
-use simplex::signer::{KeyProvider, Signer};
+use simplex::signer::{KeyOrigin, Signer};
 use simplex::transaction::partial_input::IssuanceInput;
 use simplex::transaction::{FinalTransaction, PartialInput, PartialOutput, RequiredSignature};
 
-fn make_confidential_to_bob<K1: KeyProvider, K2: KeyProvider>(
+fn make_confidential_to_bob<K1: KeyOrigin, K2: KeyOrigin>(
     alice: &Signer<K1>,
     bob: &Signer<K2>,
     asset: AssetId,
@@ -22,7 +22,7 @@ fn make_confidential_to_bob<K1: KeyProvider, K2: KeyProvider>(
     Ok(())
 }
 
-fn issue_confidential_to_alice<K1: KeyProvider, K2: KeyProvider>(
+fn issue_confidential_to_alice<K1: KeyOrigin, K2: KeyOrigin>(
     alice: &Signer<K1>,
     bob: &Signer<K2>,
 ) -> anyhow::Result<()> {

--- a/fixtures/tests/confidential_test.rs
+++ b/fixtures/tests/confidential_test.rs
@@ -1,10 +1,14 @@
 use simplex::simplicityhl::elements::AssetId;
 
-use simplex::signer::Signer;
+use simplex::signer::{KeyProvider, Signer};
 use simplex::transaction::partial_input::IssuanceInput;
 use simplex::transaction::{FinalTransaction, PartialInput, PartialOutput, RequiredSignature};
 
-fn make_confidential_to_bob(alice: &Signer, bob: &Signer, asset: AssetId) -> anyhow::Result<()> {
+fn make_confidential_to_bob<K1: KeyProvider, K2: KeyProvider>(
+    alice: &Signer<K1>,
+    bob: &Signer<K2>,
+    asset: AssetId,
+) -> anyhow::Result<()> {
     let mut ft = FinalTransaction::new();
 
     ft.add_output(
@@ -18,7 +22,10 @@ fn make_confidential_to_bob(alice: &Signer, bob: &Signer, asset: AssetId) -> any
     Ok(())
 }
 
-fn issue_confidential_to_alice(alice: &Signer, bob: &Signer) -> anyhow::Result<()> {
+fn issue_confidential_to_alice<K1: KeyProvider, K2: KeyProvider>(
+    alice: &Signer<K1>,
+    bob: &Signer<K2>,
+) -> anyhow::Result<()> {
     let utxos = bob.get_utxos()?;
 
     let mut ft = FinalTransaction::new();

--- a/fixtures/tests/confidential_test.rs
+++ b/fixtures/tests/confidential_test.rs
@@ -13,7 +13,7 @@ fn make_confidential_to_bob<K1: KeyOrigin, K2: KeyOrigin>(
 
     ft.add_output(
         PartialOutput::new(bob.get_address().script_pubkey(), 1000, asset)
-            .with_blinding_key(bob.get_blinding_public_key()),
+            .with_blinding_key(bob.get_blinding_public_key()?),
     );
 
     let tx_receipt = alice.broadcast(&ft)?;
@@ -38,7 +38,7 @@ fn issue_confidential_to_alice<K1: KeyOrigin, K2: KeyOrigin>(
 
     ft.add_output(
         PartialOutput::new(alice.get_address().script_pubkey(), 1000, issuance_details.asset_id)
-            .with_blinding_key(alice.get_blinding_public_key()),
+            .with_blinding_key(alice.get_blinding_public_key()?),
     );
     ft.add_output(
         PartialOutput::new(
@@ -46,7 +46,7 @@ fn issue_confidential_to_alice<K1: KeyOrigin, K2: KeyOrigin>(
             100,
             issuance_details.inflation_asset_id,
         )
-        .with_blinding_key(alice.get_blinding_public_key()),
+        .with_blinding_key(alice.get_blinding_public_key()?),
     );
 
     let tx_receipt = bob.broadcast(&ft)?;

--- a/fixtures/tests/reissuance_test.rs
+++ b/fixtures/tests/reissuance_test.rs
@@ -1,12 +1,16 @@
 use simplex::simplicityhl::elements::AssetId;
 
-use simplex::signer::Signer;
+use simplex::signer::{KeyProvider, Signer};
 use simplex::transaction::partial_input::IssuanceInput;
 use simplex::transaction::{
     FinalTransaction, IssuanceDetails, PartialInput, PartialOutput, RequiredSignature, TxReceipt,
 };
 
-fn make_confidential_to_bob<'a>(alice: &'a Signer, bob: &Signer, asset: AssetId) -> anyhow::Result<TxReceipt<'a>> {
+fn make_confidential_to_bob<'a, K1: KeyProvider, K2: KeyProvider>(
+    alice: &'a Signer<K1>,
+    bob: &Signer<K2>,
+    asset: AssetId,
+) -> anyhow::Result<TxReceipt<'a>> {
     let mut ft = FinalTransaction::new();
 
     ft.add_output(
@@ -20,9 +24,9 @@ fn make_confidential_to_bob<'a>(alice: &'a Signer, bob: &Signer, asset: AssetId)
     Ok(tx_receipt)
 }
 
-fn issue_explicit_to_alice_with_reissuance<'a>(
-    alice: &Signer,
-    bob: &'a Signer,
+fn issue_explicit_to_alice_with_reissuance<'a, K1: KeyProvider, K2: KeyProvider>(
+    alice: &Signer<K1>,
+    bob: &'a Signer<K2>,
 ) -> anyhow::Result<(TxReceipt<'a>, IssuanceDetails)> {
     let utxos = bob.get_utxos()?;
 
@@ -54,8 +58,8 @@ fn issue_explicit_to_alice_with_reissuance<'a>(
     Ok((tx_receipt, issuance_details))
 }
 
-fn reissue_tokens_to_bob<'a>(
-    bob: &'a Signer,
+fn reissue_tokens_to_bob<'a, K: KeyProvider>(
+    bob: &'a Signer<K>,
     issuance_details: &IssuanceDetails,
     reissuance_amount: u64,
 ) -> anyhow::Result<TxReceipt<'a>> {

--- a/fixtures/tests/reissuance_test.rs
+++ b/fixtures/tests/reissuance_test.rs
@@ -1,12 +1,12 @@
 use simplex::simplicityhl::elements::AssetId;
 
-use simplex::signer::{KeyProvider, Signer};
+use simplex::signer::{KeyOrigin, Signer};
 use simplex::transaction::partial_input::IssuanceInput;
 use simplex::transaction::{
     FinalTransaction, IssuanceDetails, PartialInput, PartialOutput, RequiredSignature, TxReceipt,
 };
 
-fn make_confidential_to_bob<'a, K1: KeyProvider, K2: KeyProvider>(
+fn make_confidential_to_bob<'a, K1: KeyOrigin, K2: KeyOrigin>(
     alice: &'a Signer<K1>,
     bob: &Signer<K2>,
     asset: AssetId,
@@ -24,7 +24,7 @@ fn make_confidential_to_bob<'a, K1: KeyProvider, K2: KeyProvider>(
     Ok(tx_receipt)
 }
 
-fn issue_explicit_to_alice_with_reissuance<'a, K1: KeyProvider, K2: KeyProvider>(
+fn issue_explicit_to_alice_with_reissuance<'a, K1: KeyOrigin, K2: KeyOrigin>(
     alice: &Signer<K1>,
     bob: &'a Signer<K2>,
 ) -> anyhow::Result<(TxReceipt<'a>, IssuanceDetails)> {
@@ -58,7 +58,7 @@ fn issue_explicit_to_alice_with_reissuance<'a, K1: KeyProvider, K2: KeyProvider>
     Ok((tx_receipt, issuance_details))
 }
 
-fn reissue_tokens_to_bob<'a, K: KeyProvider>(
+fn reissue_tokens_to_bob<'a, K: KeyOrigin>(
     bob: &'a Signer<K>,
     issuance_details: &IssuanceDetails,
     reissuance_amount: u64,

--- a/fixtures/tests/reissuance_test.rs
+++ b/fixtures/tests/reissuance_test.rs
@@ -15,7 +15,7 @@ fn make_confidential_to_bob<'a, K1: KeyOrigin, K2: KeyOrigin>(
 
     ft.add_output(
         PartialOutput::new(bob.get_address().script_pubkey(), 1000, asset)
-            .with_blinding_key(bob.get_blinding_public_key()),
+            .with_blinding_key(bob.get_blinding_public_key()?),
     );
 
     let tx_receipt = alice.broadcast(&ft)?;
@@ -49,7 +49,7 @@ fn issue_explicit_to_alice_with_reissuance<'a, K1: KeyOrigin, K2: KeyOrigin>(
             100,
             issuance_details.inflation_asset_id,
         )
-        .with_blinding_key(bob.get_blinding_public_key()),
+        .with_blinding_key(bob.get_blinding_public_key()?),
     );
 
     let tx_receipt = bob.broadcast(&ft)?;
@@ -73,7 +73,7 @@ fn reissue_tokens_to_bob<'a, K: KeyOrigin>(
             reissuance_token_utxo.unblinded_amount(),
             reissuance_token_utxo.unblinded_asset(),
         )
-        .with_blinding_key(bob.get_blinding_public_key()),
+        .with_blinding_key(bob.get_blinding_public_key()?),
     );
 
     ft.add_issuance_input(


### PR DESCRIPTION
<!-- 
Thank you for contributing to Simplex! 

Before opening a pull request, please check out the contributing guidelines.

Make sure that the CHANGELOG.md is up to date and starts with the following header:

```
# Changelog

## [<version>|Unreleased]

- <Pull request changes description>.
```

Also consider ticking the relevant statements below and updating README.md.
-->

- [ ] This PR suggests a **bug fix** and I've added the necessary tests.
- [ ] This PR introduces a **new feature** and I've discussed the update in an Issue or with the team.
- [x] This PR is just a **minor change** like a typo fix.

---

<!-- Add the PR description here. -->
Add the KeyOrigin trait to move the logic for determining keys into a separate entity

* add HDKey and SingleKey
* implement the KeyOrigin trait for them and adapt tests