### PR TITLE
Follow Bitcoin 29 defaults for concurrency

### DIFF
--- a/crates/build/src/generator.rs
+++ b/crates/build/src/generator.rs
@@ -192,7 +192,7 @@ impl ArtifactsGenerator {
 
     /// Generates a single `.rs` binding file for one simf artifact.
     fn generate_simf_binding(out_dir: &Path, artifact: SimfArtifact) -> Result<String, BuildError> {
-        let output_file = out_dir.join(format!("{}.rs", &artifact.contract_name));
+        let output_file = out_dir.join(format!("{}.rs", artifact.contract_name));
 
         let mut file = fs::OpenOptions::new()
             .create(true)

--- a/crates/regtest/src/client.rs
+++ b/crates/regtest/src/client.rs
@@ -117,8 +117,8 @@ impl RegtestClient {
         bin_args.push(format!("-zmqpubhashblock=tcp://{zmq_addr}"));
         bin_args.push(format!("-zmqpubsequence=tcp://{zmq_addr}"));
 
-        bin_args.push(format!("-rpcworkqueue=64"));
-        bin_args.push(format!("-rpcthreads=16"));
+        bin_args.push("-rpcworkqueue=64".to_string());
+        bin_args.push("-rpcthreads=16".to_string());
 
         conf.args = bin_args.iter().map(std::convert::AsRef::as_ref).collect::<Vec<&str>>();
         conf.network = "liquidregtest";

--- a/crates/regtest/src/client.rs
+++ b/crates/regtest/src/client.rs
@@ -117,6 +117,9 @@ impl RegtestClient {
         bin_args.push(format!("-zmqpubhashblock=tcp://{zmq_addr}"));
         bin_args.push(format!("-zmqpubsequence=tcp://{zmq_addr}"));
 
+        bin_args.push(format!("-rpcworkqueue=64"));
+        bin_args.push(format!("-rpcthreads=16"));
+
         conf.args = bin_args.iter().map(std::convert::AsRef::as_ref).collect::<Vec<&str>>();
         conf.network = "liquidregtest";
         conf.p2p = bitcoind::P2P::Yes;


### PR DESCRIPTION
Set -rpcworkqueue=64 and -rpcthreads=16 on elementsd invocation, following upstream Bitcoin 29 defaults. This reduces some rate limit-type errors in some environments associated with electrs querying elementsd very quickly.

Fixes #77.