### PR TITLE
Add CompiledProgram to the Program structure

### DIFF
--- a/crates/build/src/generator.rs
+++ b/crates/build/src/generator.rs
@@ -265,9 +265,9 @@ impl ArtifactsGenerator {
                 pub const SOURCE: &'static str = #include_simf_module::#include_simf_source_const;
 
                 #[must_use]
-                pub fn new(arguments: impl ArgumentsTrait + 'static) -> Self {
+                pub fn new(arguments: &impl ArgumentsTrait) -> Self {
                     Self {
-                        program: Program::new(Self::SOURCE, Box::new(arguments)),
+                        program: Program::new(Self::SOURCE, arguments),
                     }
                 }
 

--- a/crates/sdk/src/program/core.rs
+++ b/crates/sdk/src/program/core.rs
@@ -83,7 +83,7 @@ pub trait ProgramTrait: DynClone {
 #[derive(Clone)]
 pub struct Program {
     pub_key: XOnlyPublicKey,
-    compiled_program: CompiledProgram,
+    compiled: CompiledProgram,
     storage: Vec<[u8; 32]>,
 }
 
@@ -105,7 +105,7 @@ impl ProgramTrait for Program {
         network: &SimplicityNetwork,
     ) -> Result<ElementsEnv<Arc<Transaction>>, ProgramError> {
         let genesis_hash = network.genesis_block_hash();
-        let cmr = self.compiled_program.commit().cmr();
+        let cmr = self.compiled.commit().cmr();
         let utxos: Vec<TxOut> = pst.inputs().iter().filter_map(|x| x.witness_utxo.clone()).collect();
 
         if utxos.len() <= input_index {
@@ -137,7 +137,7 @@ impl ProgramTrait for Program {
                 .collect(),
             u32::try_from(input_index)?,
             cmr,
-            self.control_block()?,
+            self.control_block(),
             None,
             genesis_hash,
         ))
@@ -151,7 +151,7 @@ impl ProgramTrait for Program {
         network: &SimplicityNetwork,
     ) -> Result<(Arc<RedeemNode>, Value), ProgramError> {
         let satisfied = self
-            .compiled_program
+            .compiled
             .satisfy(witness.clone())
             .map_err(ProgramError::WitnessSatisfaction)?;
 
@@ -190,26 +190,30 @@ impl ProgramTrait for Program {
             simplicity_witness_bytes,
             simplicity_program_bytes,
             cmr.as_ref().to_vec(),
-            self.control_block()?.serialize(),
+            self.control_block().serialize(),
         ])
     }
 }
 
 impl Program {
     /// Creates a new instance of the struct with the provided source string and arguments.
+    ///
+    /// # Panics
+    /// Panics if the `source` fails to compile as a Simplicity program.
     #[must_use]
-    pub fn new(source: &'static str, arguments: Box<dyn ArgumentsTrait>) -> Self {
-        let compiled_program = CompiledProgram::new_with_unstable(
+    pub fn new(source: &'static str, arguments: &dyn ArgumentsTrait) -> Self {
+        let compiled = CompiledProgram::new_with_unstable(
             source,
             &UnstableFeatures::all(),
             arguments.build_arguments(),
             GlobalConfig::get_include_debug_symbols(),
             Box::new(ElementsJetHinter),
-        ).expect("Failed to compile Simplicity program");
+        )
+        .expect("Failed to compile Simplicity program");
 
         Self {
             pub_key: tr_unspendable_key(),
-            compiled_program,
+            compiled,
             storage: Vec::new(),
         }
     }
@@ -268,7 +272,7 @@ impl Program {
     /// Panics if generating the taproot spending information fails.
     #[must_use]
     pub fn get_tr_address(&self, network: &SimplicityNetwork) -> Address {
-        let spend_info = self.taproot_spending_info().unwrap();
+        let spend_info = self.taproot_spending_info();
 
         Address::p2tr(
             secp256k1::SECP256K1,
@@ -296,7 +300,10 @@ impl Program {
     /// # Errors
     /// Returns a `ProgramError` if compilation fails or generating ABI metadata fails.
     pub fn get_argument_types(&self) -> Result<Parameters, ProgramError> {
-        let abi_meta = self.compiled_program.generate_abi_meta().map_err(ProgramError::ProgramGenAbiMeta)?;
+        let abi_meta = self
+            .compiled
+            .generate_abi_meta()
+            .map_err(ProgramError::ProgramGenAbiMeta)?;
 
         Ok(abi_meta.param_types)
     }
@@ -306,16 +313,19 @@ impl Program {
     /// # Errors
     /// Returns a `ProgramError` if compilation fails or generating ABI metadata fails.
     pub fn get_witness_types(&self) -> Result<WitnessTypes, ProgramError> {
-        let abi_meta = self.compiled_program.generate_abi_meta().map_err(ProgramError::ProgramGenAbiMeta)?;
+        let abi_meta = self
+            .compiled
+            .generate_abi_meta()
+            .map_err(ProgramError::ProgramGenAbiMeta)?;
 
         Ok(abi_meta.witness_types)
     }
 
-    fn script_version(&self) -> Result<(Script, taproot::LeafVersion), ProgramError> {
-        let cmr = self.compiled_program.commit().cmr();
+    fn script_version(&self) -> (Script, taproot::LeafVersion) {
+        let cmr = self.compiled.commit().cmr();
         let script = Script::from(cmr.as_ref().to_vec());
 
-        Ok((script, leaf_version()))
+        (script, leaf_version())
     }
 
     fn taproot_leaf_depths(total_leaves: usize) -> Vec<usize> {
@@ -337,9 +347,9 @@ impl Program {
         depths
     }
 
-    fn taproot_spending_info(&self) -> Result<taproot::TaprootSpendInfo, ProgramError> {
+    fn taproot_spending_info(&self) -> taproot::TaprootSpendInfo {
         let mut builder = taproot::TaprootBuilder::new();
-        let (script, version) = self.script_version()?;
+        let (script, version) = self.script_version();
         let depths = Self::taproot_leaf_depths(1 + self.get_storage_len());
 
         builder = builder
@@ -352,16 +362,16 @@ impl Program {
                 .expect("tap tree should be valid");
         }
 
-        Ok(builder
+        builder
             .finalize(secp256k1::SECP256K1, self.pub_key)
-            .expect("tap tree should be valid"))
+            .expect("tap tree should be valid")
     }
 
-    fn control_block(&self) -> Result<taproot::ControlBlock, ProgramError> {
-        let info = self.taproot_spending_info()?;
-        let script_ver = self.script_version()?;
+    fn control_block(&self) -> taproot::ControlBlock {
+        let info = self.taproot_spending_info();
+        let script_ver = self.script_version();
 
-        Ok(info.control_block(&script_ver).expect("control block should exist"))
+        info.control_block(&script_ver).expect("control block should exist")
     }
 }
 
@@ -400,7 +410,7 @@ mod tests {
     }
 
     fn dummy_program() -> Program {
-        Program::new(DUMMY_PROGRAM, Box::new(EmptyArguments))
+        Program::new(DUMMY_PROGRAM, &EmptyArguments)
     }
 
     fn dummy_network() -> SimplicityNetwork {

--- a/crates/sdk/src/program/core.rs
+++ b/crates/sdk/src/program/core.rs
@@ -77,14 +77,13 @@ pub trait ProgramTrait: DynClone {
     ) -> Result<Vec<Vec<u8>>, ProgramError>;
 }
 
-/// Represents a program structure containing its source, a public key, arguments, and associated storage.
+/// Represents a program structure containing its public key, compiled program, and associated storage.
 ///
 /// Abstraction giving the power to execute Simplicity contracts without specifying any additional parameters.
 #[derive(Clone)]
 pub struct Program {
-    source: &'static str,
     pub_key: XOnlyPublicKey,
-    arguments: Box<dyn ArgumentsTrait>,
+    compiled_program: CompiledProgram,
     storage: Vec<[u8; 32]>,
 }
 
@@ -106,7 +105,7 @@ impl ProgramTrait for Program {
         network: &SimplicityNetwork,
     ) -> Result<ElementsEnv<Arc<Transaction>>, ProgramError> {
         let genesis_hash = network.genesis_block_hash();
-        let cmr = self.load()?.commit().cmr();
+        let cmr = self.compiled_program.commit().cmr();
         let utxos: Vec<TxOut> = pst.inputs().iter().filter_map(|x| x.witness_utxo.clone()).collect();
 
         if utxos.len() <= input_index {
@@ -152,7 +151,7 @@ impl ProgramTrait for Program {
         network: &SimplicityNetwork,
     ) -> Result<(Arc<RedeemNode>, Value), ProgramError> {
         let satisfied = self
-            .load()?
+            .compiled_program
             .satisfy(witness.clone())
             .map_err(ProgramError::WitnessSatisfaction)?;
 
@@ -200,10 +199,17 @@ impl Program {
     /// Creates a new instance of the struct with the provided source string and arguments.
     #[must_use]
     pub fn new(source: &'static str, arguments: Box<dyn ArgumentsTrait>) -> Self {
-        Self {
+        let compiled_program = CompiledProgram::new_with_unstable(
             source,
+            &UnstableFeatures::all(),
+            arguments.build_arguments(),
+            GlobalConfig::get_include_debug_symbols(),
+            Box::new(ElementsJetHinter),
+        ).expect("Failed to compile Simplicity program");
+
+        Self {
             pub_key: tr_unspendable_key(),
-            arguments,
+            compiled_program,
             storage: Vec::new(),
         }
     }
@@ -290,8 +296,7 @@ impl Program {
     /// # Errors
     /// Returns a `ProgramError` if compilation fails or generating ABI metadata fails.
     pub fn get_argument_types(&self) -> Result<Parameters, ProgramError> {
-        let compiled = self.load()?;
-        let abi_meta = compiled.generate_abi_meta().map_err(ProgramError::ProgramGenAbiMeta)?;
+        let abi_meta = self.compiled_program.generate_abi_meta().map_err(ProgramError::ProgramGenAbiMeta)?;
 
         Ok(abi_meta.param_types)
     }
@@ -301,27 +306,13 @@ impl Program {
     /// # Errors
     /// Returns a `ProgramError` if compilation fails or generating ABI metadata fails.
     pub fn get_witness_types(&self) -> Result<WitnessTypes, ProgramError> {
-        let compiled = self.load()?;
-        let abi_meta = compiled.generate_abi_meta().map_err(ProgramError::ProgramGenAbiMeta)?;
+        let abi_meta = self.compiled_program.generate_abi_meta().map_err(ProgramError::ProgramGenAbiMeta)?;
 
         Ok(abi_meta.witness_types)
     }
 
-    fn load(&self) -> Result<CompiledProgram, ProgramError> {
-        let compiled = CompiledProgram::new_with_unstable(
-            self.source,
-            &UnstableFeatures::all(),
-            self.arguments.build_arguments(),
-            GlobalConfig::get_include_debug_symbols(),
-            Box::new(ElementsJetHinter),
-        )
-        .map_err(ProgramError::Compilation)?;
-
-        Ok(compiled)
-    }
-
     fn script_version(&self) -> Result<(Script, taproot::LeafVersion), ProgramError> {
-        let cmr = self.load()?.commit().cmr();
+        let cmr = self.compiled_program.commit().cmr();
         let script = Script::from(cmr.as_ref().to_vec());
 
         Ok((script, leaf_version()))

--- a/crates/sdk/src/program/core.rs
+++ b/crates/sdk/src/program/core.rs
@@ -209,7 +209,7 @@ impl Program {
             GlobalConfig::get_include_debug_symbols(),
             Box::new(ElementsJetHinter),
         )
-        .expect("Failed to compile Simplicity program");
+        .expect("Failed to compile a Simplicity program");
 
         Self {
             pub_key: tr_unspendable_key(),

--- a/crates/sdk/src/program/error.rs
+++ b/crates/sdk/src/program/error.rs
@@ -1,10 +1,6 @@
 /// Errors that can occur when compiling, preparing, and executing Simplicity programs.
 #[derive(Debug, thiserror::Error)]
 pub enum ProgramError {
-    /// Error thrown when compiling the raw Simplicity program source fails.
-    #[error("Failed to compile Simplicity program: {0}")]
-    Compilation(String),
-
     /// Error indicating failure while matching or satisfying witness values to the program requirements.
     #[error("Failed to satisfy witness: {0}")]
     WitnessSatisfaction(String),

--- a/examples/basic/tests/basic_test.rs
+++ b/examples/basic/tests/basic_test.rs
@@ -12,7 +12,7 @@ fn get_p2pk(context: &simplex::TestContext) -> (P2pkProgram, Script) {
         public_key: signer.get_schnorr_public_key().serialize(),
     };
 
-    let p2pk = P2pkProgram::new(arguments);
+    let p2pk = P2pkProgram::new(&arguments);
     let p2pk_script = p2pk.get_script_pubkey(context.get_network());
 
     (p2pk, p2pk_script)

--- a/fixtures/tests/basic_test.rs
+++ b/fixtures/tests/basic_test.rs
@@ -12,7 +12,7 @@ fn get_p2pk(context: &simplex::TestContext) -> (P2pkProgram, Script) {
         public_key: signer.get_schnorr_public_key().serialize(),
     };
 
-    let p2pk = P2pkProgram::new(arguments);
+    let p2pk = P2pkProgram::new(&arguments);
     let p2pk_script = p2pk.get_script_pubkey(context.get_network());
 
     (p2pk, p2pk_script)

--- a/fixtures/tests/log_level.rs
+++ b/fixtures/tests/log_level.rs
@@ -7,7 +7,7 @@ fn setup_dummy(context: &simplex::TestContext) -> (DummyPanicProgram, simplex::s
     let signer = context.get_default_signer();
 
     let dummy =
-        DummyPanicProgram::new(DummyPanicArguments::default()).with_taproot_pubkey(signer.get_schnorr_public_key());
+        DummyPanicProgram::new(&DummyPanicArguments::default()).with_taproot_pubkey(signer.get_schnorr_public_key());
 
     let script = dummy.get_script_pubkey(context.get_network());
 

--- a/fixtures/tests/multidep_test.rs
+++ b/fixtures/tests/multidep_test.rs
@@ -8,7 +8,7 @@ use simplex_fixtures::artifacts::imports::multidep::derived_multidep::{MultidepA
 fn get_multidep(context: &simplex::TestContext) -> (MultidepProgram, Script) {
     let arguments = MultidepArguments { prev_hash: 5 };
 
-    let p2pk = MultidepProgram::new(arguments);
+    let p2pk = MultidepProgram::new(&arguments);
     let p2pk_script = p2pk.get_script_pubkey(context.get_network());
 
     (p2pk, p2pk_script)

--- a/fixtures/tests/nested_sig.rs
+++ b/fixtures/tests/nested_sig.rs
@@ -12,7 +12,7 @@ fn get_nested_sig(context: &simplex::TestContext) -> (NestedSigProgram, Script) 
         public_key: signer.get_schnorr_public_key().serialize(),
     };
 
-    let program = NestedSigProgram::new(arguments);
+    let program = NestedSigProgram::new(&arguments);
     let script = program.get_script_pubkey(context.get_network());
 
     (program, script)


### PR DESCRIPTION
<!-- 
Thank you for contributing to Simplex! 

Before opening a pull request, please check out the contributing guidelines.

Make sure that the CHANGELOG.md is up to date and starts with the following header:

```
# Changelog

## [<version>|Unreleased]

- <Pull request changes description>.
```

Also consider ticking the relevant statements below and updating README.md.
-->

- [ ] This PR suggests a **bug fix** and I've added the necessary tests.
- [ ] This PR introduces a **new feature** and I've discussed the update in an Issue or with the team.
- [ ] This PR is just a **minor change** like a typo fix.

---

<!-- Add the PR description here. -->
In the `Program` structure, `source` and `arguments` were previously used only within the `load` function, which returned a `CompiledProgram` object. This PR introduced an optimization that creates a `CompiledProgram` within the `new` function and stores it in the `Program` structure. This change optimizes the retrieval of the contract’s `script_pubkey` and other functions, thereby speeding up the entire flow.