### PR TITLE
Fix bug with project root generation

### DIFF
--- a/crates/build/src/generator.rs
+++ b/crates/build/src/generator.rs
@@ -134,7 +134,7 @@ impl ArtifactsGenerator {
             fs::create_dir_all(parent)?;
         }
 
-        let source_entry = Self::process_content(source, validated_deps)?;
+        let source_entry = Self::process_content(source, base_dir, validated_deps)?;
         fs::write(&mirrored_path, &source_entry.content)?;
 
         let relative_path_str = relative_path.display().to_string();
@@ -152,15 +152,15 @@ impl ArtifactsGenerator {
     }
 
     /// Reads and processes the content of a `.simf` file.
-    fn process_content(source: &Path, validated_deps: &ValidatedDeps) -> Result<SourceEntry, BuildError> {
-        let parent_dir = source.parent().ok_or_else(|| {
-            BuildError::GenerationFailed(format!("Path '{}' has no parent directory", source.display()))
-        })?;
-
+    fn process_content(
+        source: &Path,
+        project_root: &Path,
+        validated_deps: &ValidatedDeps,
+    ) -> Result<SourceEntry, BuildError> {
         let canon_source = CanonPath::canonicalize(source).map_err(BuildError::PathCanonicalization)?;
         let content = fs::read_to_string(source)?;
         let canon_source_file = CanonSourceFile::new(canon_source, Arc::from(content));
-        let dependency_map = Self::build_dependency_map(validated_deps, parent_dir)?;
+        let dependency_map = Self::build_dependency_map(validated_deps, project_root)?;
 
         let template = TemplateProgram::new_with_dep(
             canon_source_file.clone(),


### PR DESCRIPTION

<!-- 
Thank you for contributing to Simplex! 

Before opening a pull request, please check out the contributing guidelines.

Make sure that the CHANGELOG.md is up to date and starts with the following header:

```
# Changelog

## [<version>|Unreleased]

- <Pull request changes description>.
```

Also consider ticking the relevant statements below and updating README.md.
-->

- [x] This PR suggests a **bug fix** and I've added the necessary tests.
- [ ] This PR introduces a **new feature** and I've discussed the update in an Issue or with the team.
- [ ] This PR is just a **minor change** like a typo fix.

---

<!-- Add the PR description here. -->
Related to https://github.com/BlockstreamResearch/smplx/issues/139.

How to reproduce? 

* Create files `simf/nested/nested_2/util.simf`, `simf/nested/nested_2/assert_eq.simf` with such content.
`simf/nested/nested_2/util.simf`
```
use merkle::build_root::{get_root, hash as and_hash};
use std::lib::asserts::assert_eq_32;

pub fn get_block_value_hash(prev_hash: u32, tx1: u32, tx2: u32) -> u32 {
    let root: u32 = get_root(tx1, tx2);
    jet::xor_32(prev_hash, root)
}
```

`simf/nested/nested_2/assert_eq.simf`

```
use std::lib::asserts::assert_eq_32;
use crate::nested::nested_2::util::get_block_value_hash;

fn main() {
    let first_value: u32 = 22;
    let second_value: u32 = 22;
    assert_eq_32(first_value, second_value);
}
```

Simplex will fail to generate the correct dependency root for a nested module.


Solution: 
* Build a dependency map starting from root, not from the parent directory to the contract.